### PR TITLE
Ignore comms for non-scheduler-created events, fix maintenance sched comms

### DIFF
--- a/protohaven_api/cli.py
+++ b/protohaven_api/cli.py
@@ -550,8 +550,14 @@ class ProtohavenCLI:
         """Check recurring tasks list in Airtable, add new tasks to asana
         And notify techs about new and stale tasks that are tech_ready."""
         parser = argparse.ArgumentParser(description=self.gen_maintenance_tasks.__doc__)
-        parser.parse_args(argv)
-        report = manager.run_daily_maintenance()
+        parser.add_argument(
+            "--dryrun",
+            help="don't actually create new Asana tasks",
+            action=argparse.BooleanOptionalAction,
+            default=False,
+        )
+        args = parser.parse_args(argv)
+        report = manager.run_daily_maintenance(args.dryrun)
         print(yaml.dump([report], default_flow_style=False, default_style=""))
 
     def validate_member_clearances(self, argv):

--- a/protohaven_api/maintenance/comms.py
+++ b/protohaven_api/maintenance/comms.py
@@ -35,12 +35,12 @@ CLOSINGS = [
     "Let's keep the gears turning and the ideas flowing!",
     "Until our next digital rendezvous, stay charged up!",
     "Dream it, plan it, do it!",
-    "Innovation knows no boundaries - keep pushing forward!"
-    "Every project is a step closer to greatness - keep going!"
-    "Always be innovating!"
-    "Stay curious, stay inspired, and keep making a difference!"
-    "Remember - every circuit starts with a single connection. Keep connecting!"
-    "Your passion fuels progress — keep the fire burning!"
+    "Innovation knows no boundaries - keep pushing forward!",
+    "Every project is a step closer to greatness - keep going!",
+    "Always be innovating!",
+    "Stay curious, stay inspired, and keep making a difference!",
+    "Remember - every circuit starts with a single connection. Keep connecting!",
+    "Your passion fuels progress — keep the fire burning!",
     "You're not just making things, you're making history — keep on crafting!",
 ]
 

--- a/protohaven_api/maintenance/manager.py
+++ b/protohaven_api/maintenance/manager.py
@@ -75,14 +75,17 @@ def get_stale_tech_ready_tasks(now=None, thresh=DEFAULT_STALE_DAYS):
     return result
 
 
-def run_daily_maintenance(num_to_generate=3):
+def run_daily_maintenance(dryrun=False, num_to_generate=3):
     """Generates a bounded number of new maintenance tasks per day,
     also looks up stale tasks and creates a summary message for Techs"""
     tt = get_maintenance_needed_tasks()
     log.info(f"Found {len(tt)} needed maintenance tasks")
     tt.sort(key=lambda t: t["next_schedule"])
     tt = tt[:num_to_generate]
-    apply_maintenance_tasks(tt)
+    if dryrun:
+        log.warning("Dry run mode - skipping application of tasks")
+    else:
+        apply_maintenance_tasks(tt)
     stale = get_stale_tech_ready_tasks(thresh=DEFAULT_STALE_DAYS)
     log.info(f"Found {len(stale)} stale tasks")
     subject, body = mcomms.daily_tasks_summary(tt, stale, DEFAULT_STALE_DAYS)


### PR DESCRIPTION
Also 

* add a `--dryrun` option for sending maintenance tasks that skips actions in Asana/Airtable
* add airtable data to the cache when determining which class emails to send.

#75 