### PR TITLE
Test zero case of class publishing, retarget private instructor msg

### DIFF
--- a/protohaven_api/commands/classes_test.py
+++ b/protohaven_api/commands/classes_test.py
@@ -1,24 +1,45 @@
 """Test for class command logic"""
 
-from protohaven_api.commands.classes import Commands as C
+from protohaven_api.commands import classes as C
 from protohaven_api.integrations import neon
 
 
 def test_category_from_event_name():
     """Test a few cases to make sure categories are correctly applied"""
     assert (
-        C.neon_category_from_event_name("Digital 113: 2D Vector Creation")
+        C.Commands.neon_category_from_event_name("Digital 113: 2D Vector Creation")
         == neon.Category.PROJECT_BASED_WORKSHOP
     )
     assert (
-        C.neon_category_from_event_name("Welding 101: MIG Welding Clearance")
+        C.Commands.neon_category_from_event_name("Welding 101: MIG Welding Clearance")
         == neon.Category.SKILLS_AND_SAFETY_WORKSHOP
     )
     assert (
-        C.neon_category_from_event_name("All Member Meeting")
+        C.Commands.neon_category_from_event_name("All Member Meeting")
         == neon.Category.MEMBER_EVENT
     )
     assert (
-        C.neon_category_from_event_name("Valentine's Day Make & Take Party")
+        C.Commands.neon_category_from_event_name("Valentine's Day Make & Take Party")
         == neon.Category.SOMETHING_ELSE_AMAZING
     )
+
+
+def test_post_classes_to_neon_zero(mocker, capsys):
+    """Confirm that when there are no classes to schedule, we send no notifications"""
+    mocker.patch.object(
+        C.airtable,
+        "get_all_records",
+        return_value=[
+            {"fields": ff}
+            for ff in [
+                {"Notes": "", "Name": "Rules & Expectations"},
+                {"Notes": "", "Name": "Cancellation Policy"},
+                {"Notes": "", "Name": "Age Requirement"},
+            ]
+        ],
+    )
+    mocker.patch.object(C.airtable, "get_class_automation_schedule", return_value=[])
+    mocker.patch.object(C, "neon")
+    C.Commands.post_classes_to_neon("/asdf/ghjk", ["--apply"])
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "[]"

--- a/protohaven_api/commands/forwarding.py
+++ b/protohaven_api/commands/forwarding.py
@@ -263,7 +263,7 @@ class Commands:
             results.append(
                 {
                     "id": "",
-                    "target": "#instructors",
+                    "target": "#private-instructors",
                     "subject": "New Private Instruction Request(s) in the past 24 hours",
                     "body": (
                         "\n".join(formatted_past_day)


### PR DESCRIPTION
* Use the new `#private-instructors` channel for private instruction alerts
* Confirm that no notifications are sent when no classes are scheduled