### PR TITLE
Fix Square txn alerts, finalize discord automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ source venv/bin/activate
 pip install -r requirements.txt
 pip install -e .
 
+# Create the static build file destination for frontend assets
+mkdir -p protohaven_api/static/svelte
+# Then follow the steps at "Pushing updates" below.
+
 # Having a separate socket config allows us to bind to privileged ports (i.e. 80) without root access
 sudo cp ./protohaven_api.service /lib/systemd/system/protohaven_api.service
 sudo cp ./protohaven_api.socket /lib/systemd/system/protohaven_api.socket
@@ -97,21 +101,40 @@ git checkout <release_name>
 ```
 
 
-Next, build the static pages:
+Next, build the static pages (Note: you may likely have to build on your dev machine and scp them to the server):
 
 ```
 cd svelte
 npm run build
 rm -r ../protohaven_api/static/svelte
 cp -r ./build ../protohaven_api/static/svelte
+
+# To push to the server
+scp -r build <USER>@<ADDRESS>:/home/<USER>/staging_protohaven_api/svelte/build
+
+# You may also need to push the config file
+scp config.yaml <USER>@<ADDRESS>:/home/<USER>/staging_protohaven_api/config_new.yaml
+
+```
+
+Then SSH into the server and copy over the build files, leaving a copy of the old config just in case
+
+```
+cd path/to/staging_protohaven_api
+rm -r ./protohaven_api/static/svelte/* && cp -r ./svelte/build ./protohaven_api/static/svelte
+cp config.yaml config_old_v0_XX_XX.yaml
+mv config_new.yaml config.yaml
 ```
 
 Finally, restart the service and check its status
 
 ```
+# For prod; staging TODO
 sudo systemctl restart protohaven_api.service
 sudo systemctl status protohaven_api.service
 ```
+
+When staging is observed to work properly, do the same for prod.
 
 # Common Actions
 

--- a/protohaven_api/commands/decorator.py
+++ b/protohaven_api/commands/decorator.py
@@ -2,6 +2,8 @@
 import argparse
 import functools
 
+import yaml
+
 
 def command(*parser_args):
     """Returns a configured decorator that provides help info based on the function comment
@@ -27,3 +29,14 @@ def arg(*args, **kwargs):
     """Allows specifying of arguments in a parser.Argument call, but instead via decorato"""
     assert len(args) == 1
     return args[0], kwargs
+
+
+def load_yaml(path):
+    """Loads yaml file from a path"""
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f.read())
+
+
+def print_yaml(data):
+    """Prints yaml to stdout"""
+    print(yaml.dump(data, default_flow_style=False, default_style=""))

--- a/protohaven_api/commands/finances.py
+++ b/protohaven_api/commands/finances.py
@@ -6,10 +6,9 @@ import re
 import sys
 from collections import defaultdict
 
-import yaml
 from dateutil import parser as dateparser
 
-from protohaven_api.commands.decorator import arg, command
+from protohaven_api.commands.decorator import arg, command, print_yaml
 from protohaven_api.config import (  # pylint: disable=import-error
     exec_details_footer,
     tz,
@@ -106,7 +105,7 @@ class Commands:
                 }
             ]
 
-        print(yaml.dump(result, default_flow_style=False, default_style=""))
+        print_yaml(result)
         log.info("Done")
 
     def _validate_role_membership(self, details, role):
@@ -224,7 +223,7 @@ class Commands:
                     "target": "#membership-automation",
                 }
             ]
-            print(yaml.dump(result, default_flow_style=False, default_style=""))
+            print_yaml(result)
         log.info(f"Done ({len(problems)} validation problems found)")
 
     def validate_memberships_internal(

--- a/protohaven_api/commands/finances.py
+++ b/protohaven_api/commands/finances.py
@@ -10,7 +10,11 @@ import yaml
 from dateutil import parser as dateparser
 
 from protohaven_api.commands.decorator import arg, command
-from protohaven_api.config import tz, tznow  # pylint: disable=import-error
+from protohaven_api.config import (  # pylint: disable=import-error
+    exec_details_footer,
+    tz,
+    tznow,
+)
 from protohaven_api.integrations import neon, sales  # pylint: disable=import-error
 from protohaven_api.rbac import Role
 
@@ -29,6 +33,7 @@ class Commands:
         log.info("Fetching subscription plans")
         sub_plan_map = sales.get_subscription_plan_map()
         log.info(f"Fetched {len(sub_plan_map)} subscription plans")
+        assert len(sub_plan_map) > 0  # We should at least have some plans
         now = tznow()
         log.info("Fetching subscriptions")
 
@@ -42,10 +47,15 @@ class Commands:
 
             sub_id = sub["id"]
             url = f"https://squareup.com/dashboard/subscriptions-list/{sub_id}"
-            log.debug(f"Subscription {sub_id}")
+            log.debug(f"Subscription {sub_id}: {sub}")
             plan, price = sub_plan_map.get(
                 sub["plan_variation_id"], (sub["plan_variation_id"], 0)
             )
+            if price == 0:
+                log.warning(
+                    f"Subscription plan not resolved: {sub['plan_variation_id']}"
+                )
+                continue
             tax_pct = sales.subscription_tax_pct(sub, price)
 
             log.debug(f"{plan} ${price/100} tax={tax_pct}%")
@@ -53,6 +63,7 @@ class Commands:
 
             if tax_pct < 6.9 or tax_pct > 7.1:
                 untaxed.append(f"- {cust} - {plan} - {tax_pct}% tax, {url}")
+                log.info(untaxed[-1])
 
             charged_through = dateparser.parse(sub["charged_through_date"]).astimezone(
                 tz
@@ -61,6 +72,7 @@ class Commands:
                 unpaid.append(
                     f"- {cust} - {plan} - charged through {charged_through}, {url}"
                 )
+                log.info(unpaid[-1])
 
         log.info(
             f"Processed {n} active subscriptions - {len(unpaid)} unpaid, {len(untaxed)} untaxed"
@@ -70,16 +82,16 @@ class Commands:
         if len(unpaid) > 0:
             body = (
                 f"{len(unpaid)} subscriptions active but not caught up on payments "
-                + "(showing max of 10):\n"
+                + "(showing max of 5):\n"
             )
-            body += "\n".join(unpaid[:10])
+            body += "\n".join(unpaid[:5])
 
         if len(untaxed) > 0:
             body += (
                 f"\n{len(untaxed)} subscriptions active but do not have 7% sales tax "
-                + "(showing max of 10):\n"
+                + "(showing max of 5):\n"
             )
-            body += "\n".join(untaxed[:10])
+            body += "\n".join(untaxed[:5])
             body += "\n\nPlease remedy by following the instructions at "
             body += "https://protohaven.org/wiki/shoptechs/storage_sales_tax"
 
@@ -89,7 +101,7 @@ class Commands:
                 {
                     "id": None,
                     "subject": "@Staff: Action Needed for Square Validation",
-                    "body": body,
+                    "body": body + exec_details_footer(),
                     "target": "#finance-automation",
                 }
             ]

--- a/protohaven_api/commands/forwarding.py
+++ b/protohaven_api/commands/forwarding.py
@@ -4,10 +4,9 @@ import logging
 import re
 from datetime import datetime
 
-import yaml
 from dateutil import parser as dateparser
 
-from protohaven_api.commands.decorator import arg, command
+from protohaven_api.commands.decorator import arg, command, print_yaml
 from protohaven_api.config import tz, tznow  # pylint: disable=import-error
 from protohaven_api.forecasting import techs as forecast
 from protohaven_api.integrations import (  # pylint: disable=import-error
@@ -74,7 +73,7 @@ class Commands:
             num += 1
         log.info(f"Done - {num} project request(s) generated")
 
-        print(yaml.dump(results, default_flow_style=False, default_style=""))
+        print_yaml(results)
 
     @command()
     def shop_tech_applications(self, _):
@@ -99,7 +98,7 @@ class Commands:
                 "subject": "**Open shop tech applications:**",
                 "body": body,
             }
-            print(yaml.dump([result], default_flow_style=False, default_style=""))
+            print_yaml([result])
 
     @command()
     def instructor_applications(self, _):
@@ -125,7 +124,7 @@ class Commands:
                 "subject": "**Open instructor applications:**",
                 "body": body,
             }
-            print(yaml.dump([result], default_flow_style=False, default_style=""))
+            print_yaml([result])
 
     @command()
     def class_proposals(self, _):
@@ -151,7 +150,7 @@ class Commands:
                 "subject": "**Proposed classes awaiting approval:**",
                 "body": body,
             }
-            print(yaml.dump([result], default_flow_style=False, default_style=""))
+            print_yaml([result])
 
     def _form_from_task_notes(self, notes):
         """Extract Asana form data from the Notes field of the task"""
@@ -275,7 +274,7 @@ class Commands:
                     ),
                 }
             )
-        print(yaml.dump(results, default_flow_style=False, default_style=""))
+        print_yaml(results)
 
     @command(
         arg(
@@ -308,7 +307,7 @@ class Commands:
             num += 1
         log.info(f"Found {num} open phone messages")
 
-        print(yaml.dump(results, default_flow_style=False, default_style=""))
+        print_yaml(results)
 
     def _cur_shift(self, now):
         if now.hour < 10:  # Earlier than start of shift, so prev shift
@@ -373,4 +372,4 @@ class Commands:
                 }
             )
 
-        print(yaml.dump(comms, default_flow_style=False, default_style=""))
+        print_yaml(comms)

--- a/protohaven_api/commands/roles.py
+++ b/protohaven_api/commands/roles.py
@@ -118,13 +118,15 @@ class Commands:  # pylint: disable=too-few-public-methods
             ):
                 roles_revoked += 1
 
+        result = list(roles.gen_role_comms(user_log, roles_assigned, roles_revoked))
         print(
             yaml.dump(
-                list(roles.gen_role_comms(user_log, roles_assigned, roles_revoked)),
+                result,
                 default_flow_style=False,
                 default_style="",
             )
         )
+        log.info(f"Done - generated {len(result)} comms")
 
     @command(
         arg(

--- a/protohaven_api/commands/roles.py
+++ b/protohaven_api/commands/roles.py
@@ -3,9 +3,7 @@ import argparse
 import logging
 from collections import defaultdict
 
-import yaml
-
-from protohaven_api.commands.decorator import arg, command
+from protohaven_api.commands.decorator import arg, command, print_yaml
 from protohaven_api.config import tznow
 from protohaven_api.integrations import airtable, comms, neon
 from protohaven_api.role_automation import roles
@@ -119,13 +117,7 @@ class Commands:  # pylint: disable=too-few-public-methods
                 roles_revoked += 1
 
         result = list(roles.gen_role_comms(user_log, roles_assigned, roles_revoked))
-        print(
-            yaml.dump(
-                result,
-                default_flow_style=False,
-                default_style="",
-            )
-        )
+        print_yaml(result)
         log.info(f"Done - generated {len(result)} comms")
 
     @command(

--- a/protohaven_api/commands/roles_test.py
+++ b/protohaven_api/commands/roles_test.py
@@ -114,3 +114,15 @@ def test_update_role_intents(mocker, capsys):
     got = yaml.safe_load(capsys.readouterr().out.strip())
     got_intents = {i for c in got for i in c.get("intents", [])}
     assert 999 in got_intents
+
+
+def test_update_role_intents_zero_comms(mocker, capsys):
+    """Ensure that no comms are sent if there were no changes"""
+    mocker.patch.object(r.roles, "gen_role_intents", return_value=[])
+    mocker.patch.object(r.airtable, "get_role_intents", return_value=[])
+
+    r.Commands().update_role_intents(
+        ["--apply_records", "--apply_discord", "--destructive"]
+    )
+    got = yaml.safe_load(capsys.readouterr().out.strip())
+    assert not got

--- a/protohaven_api/commands/violations.py
+++ b/protohaven_api/commands/violations.py
@@ -3,9 +3,7 @@ import argparse
 import datetime
 import logging
 
-import yaml
-
-from protohaven_api.commands.decorator import arg, command
+from protohaven_api.commands.decorator import arg, command, print_yaml
 from protohaven_api.config import tznow  # pylint: disable=import-error
 from protohaven_api.integrations import airtable  # pylint: disable=import-error
 from protohaven_api.policy_enforcement import enforcer
@@ -138,5 +136,5 @@ class Commands:  # pylint: disable=too-few-public-methods
 
         result = enforcer.gen_comms(violations, old_fees, new_fees, new_sus)
 
-        print(yaml.dump(result, default_flow_style=False, default_style=""))
+        print_yaml(result)
         log.info(f"Generated {len(result)} notification(s)")

--- a/protohaven_api/rbac.py
+++ b/protohaven_api/rbac.py
@@ -36,6 +36,7 @@ class Role:
     STAFF = {"name": "Staff", "id": "245"}
     SHOP_TECH = {"name": "Shop Tech", "id": "238"}
     SHOP_TECH_LEAD = {"name": "Shop Tech Lead", "id": "241"}
+    EDUCATION_LEAD = {"name": "Education Lead", "id": "247"}
     ONBOARDING = {"name": "Onboarding", "id": "240"}
     ADMIN = {"name": "Admin", "id": "239"}
 

--- a/protohaven_api/role_automation/comms.py
+++ b/protohaven_api/role_automation/comms.py
@@ -1,6 +1,8 @@
 """Message templates for CLI commands that generate notifications"""
 from jinja2 import Environment, PackageLoader, select_autoescape
 
+from protohaven_api.config import exec_details_footer
+
 env = Environment(
     loader=PackageLoader("protohaven_api.role_automation"),
     autoescape=select_autoescape(),
@@ -10,17 +12,25 @@ env = Environment(
 def discord_role_change_dm(logs, discord_id):
     """Generate message for techs about classes with open seats"""
     subject = "**Your Discord Roles Are Changing:**"
+    not_associated = True in ["not associated with a Neon account" in l for l in logs]
     return subject, env.get_template("discord_role_change_dm.jinja2").render(
-        logs=logs, n=len(logs), discord_id=discord_id
+        logs=logs,
+        n=len(logs),
+        discord_id=discord_id,
+        not_associated=not_associated,
     )
 
 
 def discord_role_change_summary(user_log, roles_assigned, roles_revoked):
     """Generate summary of Discord actions taken"""
     subject = "**Discord Role Automation Summary:**"
-    return subject, env.get_template("discord_role_change_summary.jinja2").render(
-        users=list(user_log.keys()),
-        n=len(user_log),
-        roles_assigned=roles_assigned,
-        roles_revoked=roles_revoked,
+    return (
+        subject,
+        env.get_template("discord_role_change_summary.jinja2").render(
+            users=list(user_log.keys()),
+            n=len(user_log),
+            roles_assigned=roles_assigned,
+            roles_revoked=roles_revoked,
+        )
+        + exec_details_footer(),
     )

--- a/protohaven_api/role_automation/comms_test.py
+++ b/protohaven_api/role_automation/comms_test.py
@@ -1,0 +1,19 @@
+"""Test comms functions"""
+
+from protohaven_api.role_automation import comms as c
+
+
+def test_discord_role_change_dm():
+    """Confirm that role change DMs are properly constructed"""
+    logs = ["ASDF", "GHJK", "not associated with a Neon account"]
+
+    # Try first with association issue
+    _, body = c.discord_role_change_dm(logs, "userid")
+    for l in logs:
+        assert l in body
+    assert "To associate your Discord membership" in body
+    assert "discord_id=userid" in body
+
+    # Association details excluded if not an issue
+    _, body = c.discord_role_change_dm(logs[0:2], "userid")
+    assert "To associate your Discord membership" not in body

--- a/protohaven_api/role_automation/roles_test.py
+++ b/protohaven_api/role_automation/roles_test.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 """Tests for role_automation functions"""
 from collections import namedtuple
 from dataclasses import replace
@@ -157,4 +158,49 @@ def test_gen_role_intents_no_neon(mocker):
             role="Techs",
             reason="not associated with a Neon account",
         ),
+    ]
+
+
+def test_sync_delayed_intents_toggling_apply(mocker):
+    """Setting apply_records to False prevents comms and does not
+    call airtable; setting to True does"""
+    mocker.patch.object(r.airtable, "delete_record", return_value=(200, None))
+    mocker.patch.object(
+        r.airtable, "insert_records", return_value=(200, {"records": [{"id": "456"}]})
+    )
+
+    i1 = r.DiscordIntent(
+        discord_id="foo",
+        rec="123",
+        action="REVOKE",
+    )
+    i2 = r.DiscordIntent(
+        discord_id="foo",
+        action="REVOKE",
+    )
+    got = {"foo": []}
+
+    # Behavior without applying records
+    r.sync_delayed_intents(
+        intents={i2.rec: i2},
+        airtable_intents={i1.rec: i1},
+        user_log=got,
+        apply_records=False,
+    )
+    r.airtable.insert_records.assert_not_called()
+    r.airtable.delete_record.assert_not_called()
+    assert not got["foo"]
+
+    # Behavior with applying records
+    r.sync_delayed_intents(
+        intents={i2.rec: i2},
+        airtable_intents={i1.rec: i1},
+        user_log=got,
+        apply_records=True,
+    )
+    r.airtable.insert_records.assert_called()
+    r.airtable.delete_record.assert_called()
+    assert got["foo"] == [
+        ("IN 14 DAYS: revoke Discord role None (None)", "456"),
+        ("CANCELLED: revoke Discord role None (Now present in Neon CRM)", "123"),
     ]

--- a/protohaven_api/role_automation/roles_test.py
+++ b/protohaven_api/role_automation/roles_test.py
@@ -200,7 +200,8 @@ def test_sync_delayed_intents_toggling_apply(mocker):
     )
     r.airtable.insert_records.assert_called()
     r.airtable.delete_record.assert_called()
+    got["foo"].sort(key=lambda i: i[0])
     assert got["foo"] == [
-        ("IN 14 DAYS: revoke Discord role None (None)", "456"),
         ("CANCELLED: revoke Discord role None (Now present in Neon CRM)", "123"),
+        ("IN 14 DAYS: revoke Discord role None (None)", "456"),
     ]

--- a/protohaven_api/role_automation/templates/discord_role_change_dm.jinja2
+++ b/protohaven_api/role_automation/templates/discord_role_change_dm.jinja2
@@ -2,7 +2,7 @@ Based on your current membership state and your involvement in groups at Protoha
 {% for l in logs %}
 - {{l}}{% endfor %}
 Roles affect your ability to see certain channels on Protohaven's discord server, and are determined by your account in Neon.
-
-If you see "not associated with a Neon account", you need to associate your Discord membership to retain your assigned Discord roles. You can do so by going to https://api.protohaven.org/member?discord_id={{discord_id}}, logging in, then clicking "Save".
-
+{% if not_associated %}
+**To associate your Discord membership and retain your assigned Discord roles, go to https://api.protohaven.org/member?discord_id={{discord_id}}, log in (if needed), then click "Save".**
+{% endif %}
 If you think any of these actions are in error, please contact membership@protohaven.org ASAP. Otherwise, no action is needed.

--- a/protohaven_api/role_automation/templates/discord_role_change_summary.jinja2
+++ b/protohaven_api/role_automation/templates/discord_role_change_summary.jinja2
@@ -1,3 +1,3 @@
 Sent DMs to {{n}} users regarding Discord role changes: {{users|join(', ')}}
 Assigned {{roles_assigned}} role(s) and revoked {{roles_revoked}} role(s).
-See [pending revocations](<https://airtable.com/appZIwlIgaq1Ps28Y/tblBgXQlOFjNqvBVm>), [full logs](<https://www.api.protohaven.org:3013/#History?sub=event_history&id=elzsp1fmpsk>)
+See [pending revocations](<https://airtable.com/appZIwlIgaq1Ps28Y/tblBgXQlOFjNqvBVm>)

--- a/svelte/src/lib/api.ts
+++ b/svelte/src/lib/api.ts
@@ -1,20 +1,11 @@
 
-function base_ws() {
-  if (window.location.href.indexOf("localhost") === -1) {
-      return "wss://api.protohaven.org";
-  }
-  return  "ws://localhost:5000";
-}
-
-function base_url() {
-  if (window.location.href.indexOf("localhost") === -1) {
-      return "https://api.protohaven.org";
-  }
-  return  "http://localhost:5000";
+export function base_ws() {
+  // Use ws:// if http://, or wss:// if https://
+  return window.location.origin.replace("http", "ws");
 }
 
 function json_req(url, data, method) {
-  return fetch(base_url() + url, {
+  return fetch(url, {
     method,
     headers: {
       'Accept': 'application/json',
@@ -48,7 +39,7 @@ export function del(url, data) {
 }
 
 export function get(url) {
-  return fetch(base_url() + url).then((rep)=>rep.text())
+  return fetch(url).then((rep)=>rep.text())
     .then((body) => {
       try {
 	    return JSON.parse(body);

--- a/svelte/src/routes/+page.svelte
+++ b/svelte/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script type="ts">
   import '../app.scss';
   import { onMount } from 'svelte';
-  import {get, post, open_ws} from '$lib/api.ts';
+  import {base_ws, get, post, open_ws} from '$lib/api.ts';
   import { Row, Card, Container } from '@sveltestrap/sveltestrap';
   import Splash from '$lib/splash.svelte';
   import SigninOk from '$lib/signin_ok.svelte';
@@ -21,6 +21,7 @@
   let violations = [];
 
   onMount(() => {
+    console.log("Base WS:", base_ws());
   });
 
 

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -1,9 +1,44 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
 
+// Base URL of the flask backend server
+const SERVER_BASE = 'http://localhost:5000';
+const WS_SERVER_BASE = 'ws://localhost:5000';
+
+// Paths to proxy to the backend. Note that we use ? instead of * at the
+// end of regex paths as many of the base paths (e.g. "/onboarding") are
+// what we want to see fetched from this vite dev server
+// See https://vitejs.dev/config/server-options#server-proxy
+const PROXY_PATHS = [
+  '^/onboarding/.',
+  '^/instructor/.',
+  '^/techs/.',
+  '^/member/.',
+  '^/instructor/.',
+  '/whoami',
+  '/class_listing',
+  '/welcome',
+];
+const WS_PROXY_PATHS = [
+  '/welcome/ws',
+];
+let proxy = {};
+for (let p of PROXY_PATHS) {
+  proxy[p] = SERVER_BASE;
+}
+for (let p of WS_PROXY_PATHS) {
+  proxy[p] = {
+    target: WS_SERVER_BASE,
+    changeOrigin: true,
+    ws: true,
+  };
+}
+console.log("Proxying endpoints to flask backend server:", proxy);
+
 export default defineConfig({
 	plugins: [sveltekit()],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
-	}
+	},
+  server: { proxy },
 });


### PR DESCRIPTION
* Adds EduLeads discord role & neon custom field 
* Some extra documentation on server deployment
* Fix Square catalog scraping for subscription plan variations - this caused Square sales tax calculation to break
*  Add testing to ensure discord role automation does not spam channels
* Don't send comms about skipped airtable operations when `--no-apply_records` is set in `update_role_intents` invocation
* Simplify svelte URL base parsing in `api.ts` - instead of mangling the URL, instead use a proxy when running svelte with `npm run dev`.
* Refactor yaml dumping code (duplicated across many commands) into `decorator.py` to appease linting