### PR TITLE
Discord automation, reverse proxy prep, message rendering improvements

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 general:
   log_level: "${LOGLEVEL}"
   server_mode: "${PH_SERVER_MODE}"
+  behind_proxy: true
   cors: "${CORS}"
   unsafe_no_rbac: "${UNSAFE_NO_RBAC}"
   session_secret: "${SESSION_SECRET}"

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 general:
   log_level: "${LOGLEVEL}"
   server_mode: "${PH_SERVER_MODE}"
-  behind_proxy: true
+  behind_proxy: false
   cors: "${CORS}"
   unsafe_no_rbac: "${UNSAFE_NO_RBAC}"
   session_secret: "${SESSION_SECRET}"

--- a/protohaven_api/cli.py
+++ b/protohaven_api/cli.py
@@ -13,6 +13,7 @@ from protohaven_api.commands import (
     development,
     finances,
     forwarding,
+    maintenance,
     reservations,
     roles,
     violations,
@@ -21,7 +22,6 @@ from protohaven_api.config import get_config, tznow
 from protohaven_api.docs_automation.docs import validate as validate_docs
 from protohaven_api.integrations import comms, neon, tasks
 from protohaven_api.integrations.data.connector import init as init_connector
-from protohaven_api.maintenance import manager
 from protohaven_api.rbac import Role
 
 cfg = get_config()
@@ -103,7 +103,7 @@ def purchase_request_alerts():
     log.info("Done")
 
 
-class ProtohavenCLI(
+class ProtohavenCLI(  # pylint: disable=too-many-ancestors
     reservations.Commands,
     classes.Commands,
     forwarding.Commands,
@@ -111,6 +111,7 @@ class ProtohavenCLI(
     development.Commands,
     violations.Commands,
     roles.Commands,
+    maintenance.Commands,
 ):
     """argparser-based CLI for protohaven operations"""
 
@@ -200,20 +201,6 @@ class ProtohavenCLI(
         parser.parse_args(argv)
         result = validate_docs()
         print(yaml.dump([result], default_flow_style=False, default_style=""))
-
-    def gen_maintenance_tasks(self, argv):
-        """Check recurring tasks list in Airtable, add new tasks to asana
-        And notify techs about new and stale tasks that are tech_ready."""
-        parser = argparse.ArgumentParser(description=self.gen_maintenance_tasks.__doc__)
-        parser.add_argument(
-            "--dryrun",
-            help="don't actually create new Asana tasks",
-            action=argparse.BooleanOptionalAction,
-            default=False,
-        )
-        args = parser.parse_args(argv)
-        report = manager.run_daily_maintenance(args.dryrun)
-        print(yaml.dump([report], default_flow_style=False, default_style=""))
 
     def validate_member_clearances(self, argv):
         """Match clearances in spreadsheet with clearances in Neon.

--- a/protohaven_api/commands/finances.py
+++ b/protohaven_api/commands/finances.py
@@ -61,7 +61,7 @@ class Commands:
             cust = cust_map.get(sub["customer_id"], sub["customer_id"])
 
             if tax_pct < 6.9 or tax_pct > 7.1:
-                untaxed.append(f"- {cust} - {plan} - {tax_pct}% tax, {url}")
+                untaxed.append(f"- {cust} - {plan} - {tax_pct}% tax ([link]({url}))")
                 log.info(untaxed[-1])
 
             charged_through = dateparser.parse(sub["charged_through_date"]).astimezone(
@@ -69,7 +69,7 @@ class Commands:
             )
             if charged_through + datetime.timedelta(days=1) < now:
                 unpaid.append(
-                    f"- {cust} - {plan} - charged through {charged_through}, {url}"
+                    f"- {cust} - {plan} - charged through {charged_through} ([link]({url}))"
                 )
                 log.info(unpaid[-1])
 
@@ -91,9 +91,8 @@ class Commands:
                 + "(showing max of 5):\n"
             )
             body += "\n".join(untaxed[:5])
-            body += "\n\nPlease remedy by following the instructions at "
-            body += "https://protohaven.org/wiki/shoptechs/storage_sales_tax"
-            body += exec_details_footer()
+            body += "\n\nPlease remedy by following the instructions "
+            body += "[here](https://protohaven.org/wiki/shoptechs/storage_sales_tax)"
 
         result = []
         if body != "":
@@ -217,8 +216,8 @@ class Commands:
         if len(problems) > 0:
             body += f"{len(problems)} membership validation problem(s) found:\n- "
             body += "\n- ".join(problems)
-            body += "\n Please remedy by following the instructions at "
-            body += "https://protohaven.org/wiki/software/membership_validation"
+            body += "\n Please remedy by following the instructions "
+            body += "[here](https://protohaven.org/wiki/software/membership_validation)"
             body += exec_details_footer()
 
             result = [

--- a/protohaven_api/commands/forwarding.py
+++ b/protohaven_api/commands/forwarding.py
@@ -92,9 +92,11 @@ class Commands:
         log.info(f"Found {num} open applications")
 
         if num > 0:
-            body = "@TechLeads, the following applicants are waiting for a decision:\n"
+            body = (
+                "@TechLeads, the following applicants are "
+                "[waiting for a decision](https://app.asana.com/0/1203664351777333):\n"
+            )
             body += "\n".join(open_applicants)
-            body += "\nDetails at https://app.asana.com/0/1203664351777333"
 
             result = {
                 "id": "",
@@ -118,9 +120,11 @@ class Commands:
 
         if num > 0:
             log.info("Generating summary email")
-            body = "The following applicants are waiting for a decision:\n"
+            body = (
+                "The following applicants are "
+                "[waiting for a decision](https://app.asana.com/0/1202211433878591):\n"
+            )
             body += "\n".join(open_applicants)
-            body += "\nDetails at https://app.asana.com/0/1202211433878591"
 
             result = {
                 "id": "",
@@ -143,10 +147,12 @@ class Commands:
         log.info(f"Found {num} proposed classes awaiting approval.")
 
         if num > 0:
-            body = "The following classes are proposed, but not yet approved for scheduling:\n"
+            lnk = "https://airtable.com/applultHGJxHNg69H/tblBHGwrU8cwVwbHI/"
+            body = (
+                "The following classes are "
+                f"[proposed, but not yet approved]({lnk}) for scheduling:\n"
+            )
             body += "\n".join(unapproved_classes)
-            body += "\nDetails at https://airtable.com/applultHGJxHNg69H/tblBHGwrU8cwVwbHI/ "
-            body += "(requires Airtable credentials)"
 
             result = {
                 "id": "",

--- a/protohaven_api/commands/maintenance.py
+++ b/protohaven_api/commands/maintenance.py
@@ -1,0 +1,49 @@
+"""Commands related to facility and equipment maintenance"""
+import argparse
+import logging
+
+from protohaven_api.commands.decorator import arg, command, print_yaml
+from protohaven_api.config import exec_details_footer  # pylint: disable=import-error
+from protohaven_api.maintenance import comms as mcomms
+from protohaven_api.maintenance import manager
+
+log = logging.getLogger("cli.maintenance")
+
+
+class Commands:
+    """Commands for managing maintenance tasks"""
+
+    @command(
+        arg(
+            "--apply",
+            help="actually create new Asana tasks",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+        ),
+    )
+    def gen_maintenance_tasks(self, args):
+        """Check recurring tasks list in Airtable, add new tasks to asana
+        And notify techs about new and stale tasks that are tech_ready."""
+        tt = manager.run_daily_maintenance(args.apply)
+        subject, body = mcomms.daily_tasks_summary(tt)
+        report = {
+            "id": "daily_maintenance",
+            "target": "#techs-live",
+            "subject": subject,
+            "body": body,
+        }
+        print_yaml([report])
+
+    @command()
+    def gen_tech_leads_maintenance_summary(self, _):
+        """Report on status of equipment maintenance & stale tasks"""
+        stale = manager.get_stale_tech_ready_tasks()
+        log.info(f"Found {len(stale)} stale tasks")
+        subject, body = mcomms.tech_leads_summary(stale, manager.DEFAULT_STALE_DAYS)
+        report = {
+            "id": "daily_maintenance",
+            "target": "#techs-leads",
+            "subject": subject,
+            "body": body + exec_details_footer(),
+        }
+        print_yaml([report])

--- a/protohaven_api/commands/maintenance.py
+++ b/protohaven_api/commands/maintenance.py
@@ -38,12 +38,16 @@ class Commands:
     def gen_tech_leads_maintenance_summary(self, _):
         """Report on status of equipment maintenance & stale tasks"""
         stale = manager.get_stale_tech_ready_tasks()
-        log.info(f"Found {len(stale)} stale tasks")
-        subject, body = mcomms.tech_leads_summary(stale, manager.DEFAULT_STALE_DAYS)
-        report = {
-            "id": "daily_maintenance",
-            "target": "#techs-leads",
-            "subject": subject,
-            "body": body + exec_details_footer(),
-        }
-        print_yaml([report])
+        report = []
+        if len(stale) > 0:
+            log.info(f"Found {len(stale)} stale tasks")
+            subject, body = mcomms.tech_leads_summary(stale, manager.DEFAULT_STALE_DAYS)
+            report = [
+                {
+                    "id": "daily_maintenance",
+                    "target": "#techs-leads",
+                    "subject": subject,
+                    "body": body + exec_details_footer(),
+                }
+            ]
+        print_yaml(report)

--- a/protohaven_api/commands/roles.py
+++ b/protohaven_api/commands/roles.py
@@ -121,6 +121,18 @@ class Commands:  # pylint: disable=too-few-public-methods
         print_yaml(result)
         log.info(f"Done - generated {len(result)} comms")
 
+    def resolve_nickname(self, first, preferred, last, pronouns):
+        """Convert neon values into a single string of Discord nickname for user"""
+        first = first.strip() if first else ""
+        preferred = preferred.strip() if preferred else ""
+        last = last.strip() if last else ""
+        pronouns = pronouns.strip() if pronouns else ""
+        first = preferred if preferred != "" else first
+        nick = f"{first} {last}" if first != last else first
+        if pronouns != "":
+            nick += f" ({pronouns})"
+        return nick
+
     @command(
         arg(
             "--apply",
@@ -180,15 +192,12 @@ class Commands:  # pylint: disable=too-few-public-methods
                 log.info(f"Limit of {args.limit} changes reached")
                 i += 1
             elif i < args.limit:
-                first = (
-                    m["Preferred Name"].strip()
-                    if "Preferred Name" in m
-                    else m.get("First Name").strip()
+                nick = self.resolve_nickname(
+                    m.get("First Name"),
+                    m.get("Preferred Name"),
+                    m.get("Last Name"),
+                    m.get("Pronouns"),
                 )
-                last = m.get("Last Name").strip()
-                nick = f"{first} {last}" if first != last else first
-                if m.get("Pronouns"):
-                    nick += f" ({m['Pronouns']})"
                 cur = user_nick.get(discord_user)
                 if not cur:
                     continue

--- a/protohaven_api/commands/roles.py
+++ b/protohaven_api/commands/roles.py
@@ -6,8 +6,8 @@ from collections import defaultdict
 from protohaven_api.commands.decorator import arg, command, print_yaml
 from protohaven_api.config import tznow
 from protohaven_api.integrations import airtable, comms, neon
-from protohaven_api.role_automation import roles
 from protohaven_api.role_automation import comms as ccom
+from protohaven_api.role_automation import roles
 
 log = logging.getLogger("cli.roles")
 
@@ -141,7 +141,9 @@ class Commands:  # pylint: disable=too-few-public-methods
             default=3,
         ),
     )
-    def enforce_discord_nicknames(self, args):
+    def enforce_discord_nicknames(
+        self, args
+    ):  # pylint: disable=too-many-locals,too-many-branches
         """Ensure nicknames of all associated Discord users are properly set.
         This only targets active members, as inactive members shouldn't
         be present in channels anyways."""
@@ -169,7 +171,9 @@ class Commands:  # pylint: disable=too-few-public-methods
             discord_user = (m.get("Discord User") or "").strip()
             if discord_user == "":
                 continue
-            if discord_user in not_associated: # Not all associated users remain in Discord
+            if (
+                discord_user in not_associated
+            ):  # Not all associated users remain in Discord
                 not_associated.remove(discord_user)
 
             if i == args.limit:
@@ -189,7 +193,10 @@ class Commands:  # pylint: disable=too-few-public-methods
                 if not cur:
                     continue
                 if nick != cur:
-                    changes.append(f"- User {discord_user} nickname change: {cur} -> {nick}{' (dry run)' if not args.apply else ''}")
+                    changes.append(
+                        f"- User {discord_user} nickname change: "
+                        f"{cur} -> {nick}{' (dry run)' if not args.apply else ''}"
+                    )
                     log.info(changes[-1])
                     if args.apply:
                         log.info(str(comms.set_discord_nickname(discord_user, nick)))
@@ -198,19 +205,23 @@ class Commands:  # pylint: disable=too-few-public-methods
         if args.warn_not_associated:
             for discord_id in not_associated:
                 subject, body = ccom.not_associated_warning(discord_id)
-                result.append({
-                    "target": f"@{discord_id}",
-                    "subject": subject,
-                    "body": body,
-                })
+                result.append(
+                    {
+                        "target": f"@{discord_id}",
+                        "subject": subject,
+                        "body": body,
+                    }
+                )
 
         if len(changes) > 0 or (len(not_associated) > 0 and args.warn_not_associated):
             subject, body = ccom.nick_change_summary(changes, not_associated)
-            result.append({
-                "target": f"#discord-automation",
-                "subject": subject,
-                "body": body,
-            })
+            result.append(
+                {
+                    "target": "#discord-automation",
+                    "subject": subject,
+                    "body": body,
+                }
+            )
 
         print_yaml(result)
 

--- a/protohaven_api/config.py
+++ b/protohaven_api/config.py
@@ -2,7 +2,7 @@
 import datetime
 import os
 import pickle
-from functools import cache
+from functools import lru_cache
 from string import Template
 
 import pytz
@@ -29,7 +29,7 @@ def tznow():
     return datetime.datetime.now(tz)
 
 
-@cache
+@lru_cache(maxsize=1)
 def load_yaml_with_env_substitution(yaml_path):
     """
     Loads a YAML file and substitutes placeholder values with corresponding environment variables.
@@ -55,14 +55,14 @@ def get_config():
     return load_yaml_with_env_substitution(os.getenv(CONFIG_YAML_ENV, CONFIG_YAML_PATH))
 
 
-@cache
+@lru_cache(maxsize=1)
 def mock_data():
     """Fetches mock data from .pkl file"""
     with open(MOCK_DATA_PATH, "rb") as f:
         return pickle.load(f)
 
 
-@cache
+@lru_cache(maxsize=1)
 def get_execution_log_link():
     """If this process is executed asynchronously via Cronicle, return a link
     to the execution log of the job. If we're not running as part of a Cronicle job,
@@ -82,4 +82,4 @@ def exec_details_footer():
     process.
     """
     l = get_execution_log_link()
-    return "" if not l else "\nExecution log: " + l
+    return "" if not l else f"\n*See [execution log]({l})*"

--- a/protohaven_api/handlers/auth.py
+++ b/protohaven_api/handlers/auth.py
@@ -1,5 +1,5 @@
 """User auth handlers for login/logout and metadata"""
-from flask import Blueprint, redirect, request, session, url_for
+from flask import Blueprint, redirect, request, session
 
 from protohaven_api import oauth
 from protohaven_api.integrations import neon
@@ -30,7 +30,8 @@ def user_fullname():
 
 
 def _redirect_uri():
-   return f"{request.url_root}/oauth_redirect"
+    return f"{request.url_root}oauth_redirect"
+
 
 @page.route("/login")
 def login_user_neon_oauth():
@@ -48,7 +49,6 @@ def login_user_neon_oauth():
 
     print("Set login referrer:", session["login_referrer"])
     return redirect(oauth.prep_request(_redirect_uri()))
-    # request.url_root + url_for(neon_oauth_redirect.__name__)))
 
 
 @page.route("/logout")

--- a/protohaven_api/handlers/auth.py
+++ b/protohaven_api/handlers/auth.py
@@ -29,6 +29,9 @@ def user_fullname():
         return None
 
 
+def _redirect_uri():
+   return f"{request.url_root}/oauth_redirect"
+
 @page.route("/login")
 def login_user_neon_oauth():
     """Redirect to Neon CRM oauth server"""
@@ -44,7 +47,7 @@ def login_user_neon_oauth():
     session["login_referrer"] = referrer
 
     print("Set login referrer:", session["login_referrer"])
-    return redirect(oauth.prep_request(f"{request.url_root}/oauth_redirect"))
+    return redirect(oauth.prep_request(_redirect_uri()))
     # request.url_root + url_for(neon_oauth_redirect.__name__)))
 
 
@@ -60,7 +63,7 @@ def logout():
 def neon_oauth_redirect():
     """Redirect back to the page the user came from for login"""
     code = request.args.get("code")
-    rep = oauth.retrieve_token(url_for("auth." + neon_oauth_redirect.__name__), code)
+    rep = oauth.retrieve_token(_redirect_uri(), code)
     session["neon_id"] = rep.get("access_token")
     session["neon_account"] = neon.fetch_account(session["neon_id"])
     referrer = session.get("login_referrer", "/")

--- a/protohaven_api/handlers/auth.py
+++ b/protohaven_api/handlers/auth.py
@@ -1,10 +1,14 @@
 """User auth handlers for login/logout and metadata"""
+import logging
+
 from flask import Blueprint, redirect, request, session
 
 from protohaven_api import oauth
 from protohaven_api.integrations import neon
 
 page = Blueprint("auth", __name__, template_folder="templates")
+
+log = logging.getLogger("handlers.auth")
 
 
 def user_email():
@@ -47,7 +51,7 @@ def login_user_neon_oauth():
         referrer = "/"
     session["login_referrer"] = referrer
 
-    print("Set login referrer:", session["login_referrer"])
+    log.info(f"Set login referrer: {session['login_referrer']}")
     return redirect(oauth.prep_request(_redirect_uri()))
 
 
@@ -67,5 +71,5 @@ def neon_oauth_redirect():
     session["neon_id"] = rep.get("access_token")
     session["neon_account"] = neon.fetch_account(session["neon_id"])
     referrer = session.get("login_referrer", "/")
-    print("Login referrer redirect:", referrer)
+    log.info(f"Login referrer redirect: {referrer}")
     return redirect(referrer)

--- a/protohaven_api/handlers/auth.py
+++ b/protohaven_api/handlers/auth.py
@@ -44,7 +44,7 @@ def login_user_neon_oauth():
     session["login_referrer"] = referrer
 
     print("Set login referrer:", session["login_referrer"])
-    return redirect(oauth.prep_request("https://api.protohaven.org/oauth_redirect"))
+    return redirect(oauth.prep_request(f"{request.url_root}/oauth_redirect"))
     # request.url_root + url_for(neon_oauth_redirect.__name__)))
 
 

--- a/protohaven_api/handlers/index.py
+++ b/protohaven_api/handlers/index.py
@@ -106,10 +106,8 @@ def welcome_sock(ws):  # pylint: disable=too-many-branches,too-many-statements
             ]
             send_membership_automation_message(
                 f"Sign-in with {data['email']} returned multiple accounts "
-                + "in Neon with same email:\n"
-                + "\n".join(urls)
-                + "\n@Staff: please deduplicate "
-                + "(see https://protohaven.org/wiki/software/membership_validation)"
+                f"in Neon with same email:\n" + "\n".join(urls) + "\n@Staff: please "
+                "[deduplicate](https://protohaven.org/wiki/software/membership_validation)"
             )
             log.info("Notified of multiple accounts")
         if len(mm) == 0:
@@ -172,21 +170,22 @@ def welcome_sock(ws):  # pylint: disable=too-many-branches,too-many-statements
                 data.get("waiver_ack", False),
             )
 
+            data[
+                "url"
+            ] = f"https://protohaven.app.neoncrm.com/admin/accounts/{m['Account ID']}"
             if result["status"] != "Active":
                 send_membership_automation_message(
-                    f"{result['firstname']} ({data['email']}) just signed in at the front desk "
-                    "but has a non-Active membership status in Neon: "
-                    f"status is {result['status']}\n"
-                    f"https://protohaven.app.neoncrm.com/admin/accounts/{m['Account ID']}\n"
-                    "https://protohaven.org/wiki/software/membership_validation"
+                    f"[{result['firstname']} ({data['email']})]({data['url']}) just signed in "
+                    "at the front desk but has a non-Active membership status in Neon: "
+                    f"status is {result['status']} "
+                    "([wiki](https://protohaven.org/wiki/software/membership_validation))\n"
                 )
                 log.info("Notified of non-active member sign in")
             elif len(result["violations"]) > 0:
                 send_membership_automation_message(
-                    f"{result['firstname']} ({data['email']}) just signed in at the front desk "
-                    f"with violations: {result['violations']}\n"
-                    f"https://protohaven.app.neoncrm.com/admin/accounts/{m['Account ID']}\n"
-                    "https://protohaven.org/wiki/software/membership_validation"
+                    f"[{result['firstname']} ({data['email']})]({data['url']}) just signed in "
+                    f"at the front desk with violations: {result['violations']} "
+                    "([wiki](https://protohaven.org/wiki/software/membership_validation))\n"
                 )
                 log.info("Notified of sign-in with violations")
     elif data["person"] == "guest":

--- a/protohaven_api/handlers/index.py
+++ b/protohaven_api/handlers/index.py
@@ -184,7 +184,7 @@ def welcome_sock(ws):  # pylint: disable=too-many-branches,too-many-statements
             elif len(result["violations"]) > 0:
                 send_membership_automation_message(
                     f"[{result['firstname']} ({data['email']})]({data['url']}) just signed in "
-                    f"at the front desk with violations: {result['violations']} "
+                    f"at the front desk with violations: `{result['violations']}` "
                     "([wiki](https://protohaven.org/wiki/software/membership_validation))\n"
                 )
                 log.info("Notified of sign-in with violations")

--- a/protohaven_api/handlers/index_test.py
+++ b/protohaven_api/handlers/index_test.py
@@ -155,7 +155,7 @@ def test_welcome_signin_membership_expired(mocker):
     index.submit_google_form.assert_called()  # Form submission even if membership is expired
     index.airtable.insert_signin.assert_called()
     index.send_membership_automation_message.assert_called_with(
-        "First (foo@bar.com) just signed in at the front desk but has a non-Active membership status in Neon: status is Inactive\nhttps://protohaven.app.neoncrm.com/admin/accounts/12345\nhttps://protohaven.org/wiki/software/membership_validation"
+        "[First (foo@bar.com)](https://protohaven.app.neoncrm.com/admin/accounts/12345) just signed in at the front desk but has a non-Active membership status in Neon: status is Inactive ([wiki](https://protohaven.org/wiki/software/membership_validation))\n"
     )
 
 
@@ -194,7 +194,7 @@ def test_welcome_signin_ok_with_violations(mocker):
         {"fields": {"Neon ID": "12345", "Notes": "This one is shown"}}
     ]
     index.send_membership_automation_message.assert_called_with(
-        "First (foo@bar.com) just signed in at the front desk with violations: [{'fields': {'Neon ID': '12345', 'Notes': 'This one is shown'}}]\nhttps://protohaven.app.neoncrm.com/admin/accounts/12345\nhttps://protohaven.org/wiki/software/membership_validation"
+        "[First (foo@bar.com)](https://protohaven.app.neoncrm.com/admin/accounts/12345) just signed in at the front desk with violations: `[{'fields': {'Neon ID': '12345', 'Notes': 'This one is shown'}}]` ([wiki](https://protohaven.org/wiki/software/membership_validation))\n"
     )
 
 

--- a/protohaven_api/integrations/airtable.py
+++ b/protohaven_api/integrations/airtable.py
@@ -2,7 +2,7 @@
 import datetime
 import logging
 from collections import defaultdict
-from functools import cache
+from functools import lru_cache
 
 from dateutil import parser as dateparser
 from dateutil.rrule import rrulestr
@@ -110,7 +110,7 @@ def log_email(neon_id, to, subject, status):
         raise RuntimeError(content)
 
 
-@cache
+@lru_cache(maxsize=1)
 def get_instructor_log_tool_codes():
     """Fetch tool codes used in the instructor log form"""
     codes = get_all_records("class_automation", "clearance_codes")
@@ -185,7 +185,7 @@ def update_recurring_task_date(task_id, date):
     )
 
 
-@cache
+@lru_cache(maxsize=1)
 def get_clearance_to_tool_map():
     """Returns a mapping of clearance codes (e.g. MWB) to individual tool codes"""
     airtable_clearances = get_all_records("tools_and_equipment", "clearances")
@@ -216,7 +216,7 @@ def insert_signin(evt):
     return insert_records([evt.to_airtable()], "people", "sign_ins")
 
 
-@cache
+@lru_cache(maxsize=1)
 def _get_announcements_cached_impl(i):  # pylint: disable=unused-argument
     return list(get_all_records("people", "sign_in_announcements"))
 

--- a/protohaven_api/integrations/data/dev_airtable.py
+++ b/protohaven_api/integrations/data/dev_airtable.py
@@ -1,7 +1,7 @@
 """Mock airtable service using canned data"""
 import json
 import uuid
-from functools import cache
+from functools import lru_cache
 from urllib.parse import urlparse
 
 from flask import Flask, Response, request
@@ -11,14 +11,14 @@ from protohaven_api.config import get_config, mock_data
 app = Flask(__file__)
 
 
-@cache
+@lru_cache(maxsize=128)
 def _base_lookup(_id):
     """Lookup base within config.yaml"""
     cfg = get_config()["airtable"]
     return {v["base_id"]: k for k, v in cfg.items()}[_id]
 
 
-@cache
+@lru_cache(maxsize=128)
 def _tbl_lookup(_id):
     """Lookup table within config.yaml"""
     cfg = get_config()["airtable"]

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -5,7 +5,7 @@ import logging
 import re
 import time
 import urllib
-from functools import cache
+from functools import lru_cache
 
 from bs4 import BeautifulSoup
 from dateutil import parser as dateparser
@@ -156,7 +156,7 @@ def fetch_attendees(event_id):
         current_page += 1
 
 
-@cache
+@lru_cache(maxsize=1)
 def fetch_clearance_codes():
     """Fetch all the possible clearance codes that can be used in Neon"""
     content = get_connector().neon_request(

--- a/protohaven_api/integrations/sales.py
+++ b/protohaven_api/integrations/sales.py
@@ -1,6 +1,6 @@
 """Square point of sale integration for Protohaven"""
 
-from functools import cache
+from functools import lru_cache
 
 from protohaven_api.config import get_config
 from protohaven_api.integrations.data.connector import get as get_connector
@@ -9,7 +9,7 @@ cfg = get_config()["square"]
 LOCATION = cfg["location"]
 
 
-@cache
+@lru_cache(maxsize=1)
 def client():
     """Gets the square client via the connector module"""
     return get_connector().square_client()

--- a/protohaven_api/integrations/tasks.py
+++ b/protohaven_api/integrations/tasks.py
@@ -185,7 +185,7 @@ def add_maintenance_task_if_not_exists(name, desc, airtable_id, section_gid=None
         },
     )
     if len(list(matching)) > 0:
-        return False  # Already exists
+        return matching[0].get("gid")  # Already exists
 
     result = _tasks().create_task(
         {
@@ -208,7 +208,7 @@ def add_maintenance_task_if_not_exists(name, desc, airtable_id, section_gid=None
         _sections().add_task_for_section(
             str(section_gid), {"body": {"data": {"task": task_gid}}}
         )
-    return True
+    return task_gid
 
 
 if __name__ == "__main__":

--- a/protohaven_api/main.py
+++ b/protohaven_api/main.py
@@ -24,6 +24,12 @@ logging.basicConfig(level=cfg["general"]["log_level"].upper())
 log = logging.getLogger("main")
 
 app = Flask(__name__)
+if cfg["general"]["behind_proxy"]:
+    from werkzeug.middleware.proxy_fix import ProxyFix
+    app.wsgi_app = ProxyFix(
+        app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1
+    )
+
 if cfg["general"]["cors"].lower() == "true":
     log.warning("CORS enabled - this should be done in dev environments only")
     CORS(app)

--- a/protohaven_api/maintenance/comms.py
+++ b/protohaven_api/maintenance/comms.py
@@ -47,15 +47,23 @@ CLOSINGS = [
 MAX_STALE_TASKS = 3
 
 
-def daily_tasks_summary(new_tasks, stale_tasks, stale_thresh):
+def daily_tasks_summary(new_tasks):
     """Generate a summary of violation and suspension state, if there is any"""
     subject = random.choice(SALUTATIONS)
-    stale_tasks.sort(key=lambda k: k["days_ago"], reverse=True)
     return subject, env.get_template("tech_daily_tasks.jinja2").render(
         closing=random.choice(CLOSINGS),
         new_count=len(new_tasks),
-        stale_count=len(stale_tasks),
         new_tasks=new_tasks,
+    )
+
+
+def tech_leads_summary(stale_tasks, stale_thresh):
+    """Generate a summary of tale tasks"""
+    stale_tasks.sort(key=lambda k: k["days_ago"], reverse=True)
+    return "Stale maintenance tasks", env.get_template(
+        "tech_leads_maintenance_status.jinja2"
+    ).render(
+        stale_count=len(stale_tasks),
         stale_thresh=stale_thresh,
         stale_tasks=stale_tasks[:MAX_STALE_TASKS],
     )

--- a/protohaven_api/maintenance/templates/tech_daily_tasks.jinja2
+++ b/protohaven_api/maintenance/templates/tech_daily_tasks.jinja2
@@ -1,12 +1,5 @@
-{% if new_count > 0 %}Today we have {{new_count}} new tech_ready task{% if new_count != 1 %}s{% endif %}:
-{% for t in new_tasks %}
-- {{ t['name'] }}{% endfor %}{% else %}There are no new tasks for today - we're caught up on scheduling!{% endif %}
-{% if stale_count > 0 %}
-We have {{stale_count}} tech_ready {% if stale_count != 1 %}tasks that haven't{% else %}task that hasn't{% endif %} seen any updates in {{stale_thresh}} days or more. These are the most stale ones:
-{% for t in stale_tasks %}
-- {{ t['name'] }} ({{ t['days_ago'] }} days stale){% endfor %}
-{% endif %}{% if new_count == 0 and stale_count == 0 %}Your comrades in tech are really on top of things - there are no new or stale tech_ready tasks today! But there's always something to do.
-{% endif %}
-To see the full list of tasks, check out the Shop & Maintenance Tasks project in Asana here: https://app.asana.com/0/1202469740885594/1204138662113052. While you're on duty, could you take a look at these and see if you can help them along? Anything you can do to help us complete these maintenance tasks would be immensely helpful.
+{% if new_count > 0 %}Today we have {{new_count}} new tech_ready task{% if new_count != 1 %}s{% endif %}:{% for t in new_tasks %}
+- [{{ t['name'] }}](https://app.asana.com/0/1202469740885594/{{ t['gid'] }}){% endfor %}{% else %}There are no new tasks for today - we're caught up on scheduling!{% endif %}
+Remember to check out the [Shop & Maintenance Tasks project](https://app.asana.com/0/1202469740885594/1204138662113052) while you're on duty and see if you can help anything along!
 {{closing}}
 Protohaven Automation

--- a/protohaven_api/maintenance/templates/tech_leads_maintenance_status.jinja2
+++ b/protohaven_api/maintenance/templates/tech_leads_maintenance_status.jinja2
@@ -1,0 +1,3 @@
+{{stale_count}} tech_ready {% if stale_count != 1 %}tasks not updated in >{{stale_thresh}} days (see [Asana](https://app.asana.com/0/1202469740885594/1204138662113052) for full list):
+{% for t in stale_tasks %}
+- [{{ t['name'] }}](https://app.asana.com/0/1202469740885594/{{ t['gid'] }}) ({{ t['days_ago'] }} days){% endfor %}

--- a/protohaven_api/oauth.py
+++ b/protohaven_api/oauth.py
@@ -1,5 +1,5 @@
 """OAuth integration with Neon CRM"""
-import sys
+# import sys
 import urllib.parse
 
 import requests
@@ -25,18 +25,18 @@ def prep_request(redirect_uri):
         "https://protohaven.app.neoncrm.com/np/oauth/auth?"
         + f"response_type=code&client_id={client_id}&redirect_uri={redirect_uri}"
     )
-    sys.stderr.write(result + "\n")
-    sys.stderr.flush()
+    # sys.stderr.write(result + "\n")
+    #sys.stderr.flush()
     return result
 
 
 def retrieve_token(redirect_uri, authorization_code):
     """Get the user token (i.e. the user's account_id) after a successful OAuth"""
     client_id, client_secret = client_data()
-    sys.stderr.write(
-        f"client_id {client_id} client_secret {client_secret}  auth_code {authorization_code}\n"
-    )
-    sys.stderr.flush()
+    #sys.stderr.write(
+    #    f"client_id {client_id} client_secret {client_secret}  auth_code {authorization_code}\n"
+    #)
+    # sys.stderr.flush()
     rep = requests.post(
         "https://app.neoncrm.com/np/oauth/token",
         data={

--- a/protohaven_api/oauth.py
+++ b/protohaven_api/oauth.py
@@ -1,5 +1,4 @@
 """OAuth integration with Neon CRM"""
-# import sys
 import urllib.parse
 
 import requests
@@ -25,18 +24,12 @@ def prep_request(redirect_uri):
         "https://protohaven.app.neoncrm.com/np/oauth/auth?"
         + f"response_type=code&client_id={client_id}&redirect_uri={redirect_uri}"
     )
-    # sys.stderr.write(result + "\n")
-    #sys.stderr.flush()
     return result
 
 
 def retrieve_token(redirect_uri, authorization_code):
     """Get the user token (i.e. the user's account_id) after a successful OAuth"""
     client_id, client_secret = client_data()
-    #sys.stderr.write(
-    #    f"client_id {client_id} client_secret {client_secret}  auth_code {authorization_code}\n"
-    #)
-    # sys.stderr.flush()
     rep = requests.post(
         "https://app.neoncrm.com/np/oauth/token",
         data={
@@ -50,13 +43,3 @@ def retrieve_token(redirect_uri, authorization_code):
     )
     rep.raise_for_status()
     return rep.json()
-
-
-if __name__ == "__main__":
-    # Note: this just proves user identity - need to track session and
-    # carefully consider permissions when deciding what data to return to them.
-    URL = "foo.bar/asdf"
-    print(prep_request(URL))
-    code = input("Enter your code:")
-    tkn = retrieve_token(URL, code)
-    print(tkn)

--- a/protohaven_api/role_automation/comms.py
+++ b/protohaven_api/role_automation/comms.py
@@ -21,6 +21,32 @@ def discord_role_change_dm(logs, discord_id):
     )
 
 
+def not_associated_warning(discord_id):
+    """Generate message about user not being associated with Neon"""
+    subject = "**Action requested - associate your Discord user:**"
+    return subject, env.get_template("not_associated.jinja2").render(
+        discord_id=discord_id,
+    )
+
+
+def nick_change_summary(changes, notified):
+    """Generate summary of Discord actions taken"""
+    subject = "**Discord Nickname Automation Summary:**"
+    m = len(notified)
+    notified = list(notified)
+    if m > 30:
+        notified = notified[:30] + ['...']
+    return (
+        subject,
+        env.get_template("discord_nick_change_summary.jinja2").render(
+            changes=list(changes),
+            n=len(changes),
+            notified=notified,
+            m=m,
+        )
+        + exec_details_footer(),
+    )
+
 def discord_role_change_summary(user_log, roles_assigned, roles_revoked):
     """Generate summary of Discord actions taken"""
     subject = "**Discord Role Automation Summary:**"

--- a/protohaven_api/role_automation/templates/discord_nick_change_summary.jinja2
+++ b/protohaven_api/role_automation/templates/discord_nick_change_summary.jinja2
@@ -1,0 +1,6 @@
+{% if n > 0 %}
+Made {{n}} nickname change(s) in Discord:
+{%for c in changes%}{{c}}{%endfor%}
+{%endif%}{% if m > 0 %}
+Notified {{m}} user(s) lacking neon association: {{notified|join(', ')}}
+{%endif%}

--- a/protohaven_api/role_automation/templates/not_associated.jinja2
+++ b/protohaven_api/role_automation/templates/not_associated.jinja2
@@ -1,0 +1,6 @@
+It appears that your Discord user isn't associated with a Protohaven member account in Neon CRM, our customer database.
+In the future, this will be required for you to have access to member and other channels on our server.
+
+**Please take 30 seconds to associate your Discord account and retain access by going [HERE](https://api.protohaven.org/member?discord_id={{discord_id}}), logging in (if needed), and clicking "Save".**
+
+If you'd like to learn more, check out the [full design and rollout plan](https://docs.google.com/document/d/1Jh1acdidZdW3ATcyJUea6t6wWK8sWNBqBaBsfWabPdM/edit?usp=sharing), contact @pwacata (Scott Martin) on Discord, or send an email to membership@protohaven.org.


### PR DESCRIPTION
Yet another PR that got away from me...

* [x] proxy passthrough mode supported via config option, with a fix to oauth redirects to support an nginx reverse proxy
* [x] replaced all instances of `@functools.cache` with `@functools.lru_cache` with explicit `maxsize` argument to mitigate OOMs on the server due to temporal cache busting
* [x] split CLI maintenance task generator into two commands - one for sending new tasks to the #techs-live channel, and the other for sending stale tasks to the #tech-leads channel. Refactored out of `cli.py` into `commands/maintenance.py` in the process.
* [x] Converted all links sent through Discord to use markdown-style `[link_embedding]()` so it's prettier
* [x] Added specific references to new/stale maintenance tasks and other listed comms which didn't have associated links
* [x] `enforce_discord_nicknames` now sends a DM to the user if their neon isn't associated, and a summary of nick changes to #discord-automation