### PR TITLE
Add account flag feature that notifies board/staff on member sign in

### DIFF
--- a/protohaven_api/handlers/index.py
+++ b/protohaven_api/handlers/index.py
@@ -124,6 +124,20 @@ def welcome_sock(ws):  # pylint: disable=too-many-branches,too-many-statements
 
             result["status"] = m.get("Account Current Membership Status", "Unknown")
             result["firstname"] = m.get("First Name")
+            data[
+                "url"
+            ] = f"https://protohaven.app.neoncrm.com/admin/accounts/{m['Account ID']}"
+
+            if "On Sign In" in (m.get("Notify Board & Staff") or ""):
+                log.warning(f"Member sign-in with notify bit set: {m}")
+                send_membership_automation_message(
+                    f"@Board and @Staff: [{result['firstname']} ({data['email']})]({data['url']}) "
+                    "just signed in at the front desk with `Notify Board & Staff = On Sign In`. "
+                    "This indicator suggests immediate followup with this member is needed. "
+                    "Click the name/email link for notes in Neon CRM."
+                )
+                log.info("Notified of member-of-interest sign in")
+
             last_announcement_ack = m.get("Announcements Acknowledged", None)
             if last_announcement_ack:
                 last_announcement_ack = dateparser.parse(
@@ -170,9 +184,6 @@ def welcome_sock(ws):  # pylint: disable=too-many-branches,too-many-statements
                 data.get("waiver_ack", False),
             )
 
-            data[
-                "url"
-            ] = f"https://protohaven.app.neoncrm.com/admin/accounts/{m['Account ID']}"
             if result["status"] != "Active":
                 send_membership_automation_message(
                     f"[{result['firstname']} ({data['email']})]({data['url']}) just signed in "

--- a/protohaven_api/integrations/data/neon.py
+++ b/protohaven_api/integrations/data/neon.py
@@ -26,6 +26,7 @@ class CustomField:
     ANNOUNCEMENTS_ACKNOWLEDGED = 154
     ZERO_COST_OK_UNTIL = 159
     PRONOUNS = 161
+    NOTIFY_BOARD_AND_STAFF = 162
 
     @classmethod
     def from_id(cls, v):

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -399,6 +399,7 @@ def search_member(email, operator="EQUAL"):
             CustomField.WAIVER_ACCEPTED,
             CustomField.ANNOUNCEMENTS_ACKNOWLEDGED,
             CustomField.API_SERVER_ROLE,
+            CustomField.NOTIFY_BOARD_AND_STAFF,
         ],
     }
     return _paginated_account_search(data)


### PR DESCRIPTION
This is controlled by the `Notify Board & Staff` account custom field in Neon CRM. It's currently just a single checkbox for `On Sign In`, but could easily be extended to notify the board on other activities by the member.