### PR TITLE
Membership deferral & activation automation

### DIFF
--- a/.gp.md
+++ b/.gp.md
@@ -2,7 +2,18 @@ Additional context is provided below.
 
 * Tests should be written in `pylint` and use `mocker` as needed. 
 * Always use `mocker.patch.object` over `mocker.patch`
-* Do not mock logging functions
+* Do not mock: logging functions, `tz`, `dateparser`
+* When providing test datetime objects, use the builtin `d()` and `t()` functions defined below.
+
+```python
+def d(i, h=0):
+    """Returns a date based on an integer, for testing. d(0,0) is 2025-01-01 @ 0:00:00 ET"""
+    # Impl omitted
+
+def t(hour, weekday=0):
+    """Create a datetime object from hour and weekday. t(0,0) is 2024-11-04 @ 0:00:00 ET"""
+    # Impl omitted
+```
 
 ```python
 def test_example(mocker):

--- a/.gp.md
+++ b/.gp.md
@@ -4,6 +4,7 @@ Additional context is provided below.
 * Always use `mocker.patch.object` over `mocker.patch`
 * Do not mock: logging functions, `tz`, `dateparser`
 * When providing test datetime objects, use the builtin `d()` and `t()` functions defined below.
+* If `return_value` is needed for a mock, define it as part of the call to `mocker.patch.object`.
 
 ```python
 def d(i, h=0):

--- a/.gp.md
+++ b/.gp.md
@@ -1,0 +1,28 @@
+Additional context is provided below.
+
+* Tests should be written in `pylint` and use `mocker` as needed. 
+* Always use `mocker.patch.object` over `mocker.patch`
+* Do not mock logging functions
+
+```python
+def test_example(mocker):
+    """Test doc header"""
+    mocker.patch.object(neon, "search_member", return_value=[])
+    got = function_to_be_tested()
+    assert got == "foo"
+```
+
+For functions decorated with `@command` that use `print_yaml`, style unit tests thusly:
+
+```python
+def test_no_response(mocker, capsys):
+    """Test an example command and verify no yaml output""" 
+    mocker.patch.object(lib, "method_used_by_command", return_value={})
+    X().test_cmd(["--test_cli_argument"])
+    captured = capsys.readouterr()
+    got = yaml.safe_load(capsys.readouterr().out.strip())
+    assert not got
+```
+
+Do not add comments to output code samples.
+

--- a/protohaven_api/cli.py
+++ b/protohaven_api/cli.py
@@ -147,8 +147,7 @@ class ProtohavenCLI(  # pylint: disable=too-many-ancestors
         print(yaml.dump([result], default_flow_style=False, default_style=""))
 
     def validate_member_clearances(self, argv):
-        """Match clearances in spreadsheet with clearances in Neon.
-        Remove this when clearance information is primarily stored in Neon."""
+        """Confirm clearance pipeline is correctly pushing clearances into Neon."""
         raise NotImplementedError("TODO implement")
 
     def sync_team_page(self, argv):

--- a/protohaven_api/commands/finances_test.py
+++ b/protohaven_api/commands/finances_test.py
@@ -1,5 +1,6 @@
 """Test methods for finance-oriented CLI commands"""
 import datetime
+import yaml
 
 from protohaven_api.commands.finances import (
     Commands as C,  # pylint: disable=import-error
@@ -221,16 +222,73 @@ def test_validate_membership_employer_too_few_bad():
 
 
 def test_generate_coupon_id():
-    raise NotImplemented()
+    got = C().generate_coupon_id(N=10)
+    assert len(got) == 10
+    assert C().generate_coupon_id(N=10) != got
 
-def test_get_sample_classes():
-    raise NotImplemented()
+def test_get_sample_classes(mocker):
+    mocker.patch.object(neon, "fetch_published_upcoming_events", return_value=[
+        {'id': 1, 'startDate': '2023-10-10', 'startTime': '10:00AM', 'name': 'Class 1'},
+        {'id': 2, 'startDate': '2023-10-11', 'startTime': '11:00AM', 'name': 'Class 2'},
+        {'id': 3, 'startDate': '2023-10-12', 'startTime': '12:00PM', 'name': 'Class 3'},
+    ])
+    mocker.patch.object(C, "event_is_suggestible", side_effect=[
+        (True, 5), (True, 1), (False, 0)
+    ])
+    result = C().get_sample_classes(10)
+    assert result == [
+        'Tuesday Oct 10, 10AM: Class 1, https://protohaven.org/e/1',
+        'Wednesday Oct 11, 11AM: Class 2, https://protohaven.org/e/2 (1 seat left!)',
+    ]
 
-def test_init_membership():
-    raise NotImplemented()
+def test_init_membership(mocker):
+    """Test init_membership"""
+    mocker.patch.object(neon, "set_membership_start_date", return_value=mocker.Mock(status_code=200))
+    mocker.patch.object(neon, "create_coupon_code", return_value=mocker.Mock(status_code=200))
+    mocker.patch.object(neon, "update_account_automation_run_status", return_value=mocker.Mock(status_code=200))
+    mocker.patch.object(C, "get_sample_classes", return_value=["class1", "class2"])
+    # Test with coupon_amount > 0
+    subject, body = C().init_membership("123", "John Doe", 50, apply=True)
+    assert subject == "John Doe: your first class is on us!"
+    assert "class1" in body
 
-def test_event_is_suggestible():
-    raise NotImplemented()
+def test_init_membership_no_classes(mocker):
+    """Test init_membership without list of classes"""
+    mocker.patch.object(neon, "set_membership_start_date", return_value=mocker.Mock(status_code=200))
+    mocker.patch.object(neon, "create_coupon_code", return_value=mocker.Mock(status_code=200))
+    mocker.patch.object(neon, "update_account_automation_run_status", return_value=mocker.Mock(status_code=200))
+    mocker.patch.object(C, "get_sample_classes", return_value=[])
+    # Test with coupon_amount > 0
+    subject, body = C().init_membership("123", "John Doe", 50, apply=True)
+    assert subject == "John Doe: your first class is on us!"
+    assert "Here's a couple basic classes" not in body
 
-def test_init_new_memberships():
-    raise NotImplemented()
+def test_event_is_suggestible(mocker):
+    mock_event_id = 123
+    mock_max_price = 100
+    tickets = [
+        {'name': 'Single Registration', 'fee': 50, 'numberRemaining': 5},
+        {'name': 'VIP Registration', 'fee': 80, 'numberRemaining': 2},
+    ]
+    mocker.patch.object(neon, 'fetch_tickets', return_value=tickets)
+    result, number_remaining = C().event_is_suggestible(mock_event_id, mock_max_price)
+    assert result is True
+    assert number_remaining == 5
+
+def test_event_is_suggestible_price_too_high(mocker):
+    mock_event_id = 123
+    mock_max_price = 40
+    tickets = [
+        {'name': 'Single Registration', 'fee': 50, 'numberRemaining': 3},
+    ]
+    mocker.patch.object(neon, 'fetch_tickets', return_value=tickets)
+    result, number_remaining = C().event_is_suggestible(mock_event_id, mock_max_price)
+    assert result is False
+
+def test_init_new_memberships(mocker, capsys):
+    """Test init_new_memberships"""
+    mocker.patch.object(neon, "get_new_members_needing_setup", return_value={})
+    C().init_new_memberships(["--apply", "--created_after=2024-01-01"])
+    captured = capsys.readouterr()
+    got = yaml.safe_load(capsys.readouterr().out.strip())
+    assert not got

--- a/protohaven_api/commands/finances_test.py
+++ b/protohaven_api/commands/finances_test.py
@@ -218,3 +218,19 @@ def test_validate_membership_employer_too_few_bad():
         d(0),
     )
     assert got == ["Missing required 2+ members in company #123"]
+
+
+def test_generate_coupon_id():
+    raise NotImplemented()
+
+def test_get_sample_classes():
+    raise NotImplemented()
+
+def test_init_membership():
+    raise NotImplemented()
+
+def test_event_is_suggestible():
+    raise NotImplemented()
+
+def test_init_new_memberships():
+    raise NotImplemented()

--- a/protohaven_api/comms_templates/__init__.py
+++ b/protohaven_api/comms_templates/__init__.py
@@ -1,0 +1,26 @@
+"""Message template functions for CLI commands"""
+from urllib.parse import quote
+from functools import lru_cache
+
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+from protohaven_api.config import tznow  # pylint: disable=import-error
+
+@lru_cache(maxsize=1)
+def _env():
+    return Environment(
+        loader=PackageLoader("protohaven_api.comms_templates"),
+        autoescape=select_autoescape(),
+    )
+
+def render(template_name, **kwargs):
+    """Returns a rendered template in two parts - subject and body.
+    Template must be of the form:
+
+    {% if subject %}Subject goes here!{% else %}Body begins{% endif %}
+    """
+    tmpl = _env().get_template(f"{template_name}.jinja2")
+    return (
+        tmpl.render(**kwargs, subject=True),
+        tmpl.render(**kwargs, subject=False),
+    )

--- a/protohaven_api/comms_templates/render_test.py
+++ b/protohaven_api/comms_templates/render_test.py
@@ -1,5 +1,7 @@
+"""Unit tests for comms_templates module"""
 from protohaven_api.comms_templates import render
 
-def test_comms_render():
-    assert render("test_template", val="test_body") == ("Test Subject", "test_body")
 
+def test_comms_render():
+    """Test that comms templates are rendered"""
+    assert render("test_template", val="test_body") == ("Test Subject", "test_body")

--- a/protohaven_api/comms_templates/render_test.py
+++ b/protohaven_api/comms_templates/render_test.py
@@ -1,0 +1,5 @@
+from protohaven_api.comms_templates import render
+
+def test_comms_render():
+    assert render("test_template", val="test_body") == ("Test Subject", "test_body")
+

--- a/protohaven_api/comms_templates/templates/init_membership.jinja2
+++ b/protohaven_api/comms_templates/templates/init_membership.jinja2
@@ -1,0 +1,15 @@
+{% if subject %}{{fname}}: your first class is on us!{% else %}Hi, {{fname}}!
+
+We're excited to have you join us at Protohaven, and we're sure you're excited to start making things - that's why we're giving you a coupon code for a free class! 
+
+{{coupon_code}}
+
+The code above is good for one free class up to ${{coupon_amount}}; this covers all our basic classes. Just add that code when you go to sign up online at https://protohaven.org/classes.
+{% if sample_classes %}
+Here's a couple basic classes with open seats that you can register for today:
+{% for l in sample_classes %}
+ - {{l}}{% endfor %}
+{% endif %}
+
+See you in the shop soon!
+{% endif %}

--- a/protohaven_api/comms_templates/templates/test_template.jinja2
+++ b/protohaven_api/comms_templates/templates/test_template.jinja2
@@ -1,0 +1,1 @@
+{% if subject %}Test Subject{% else %}{{val}}{% endif %}

--- a/protohaven_api/handlers/index.py
+++ b/protohaven_api/handlers/index.py
@@ -96,28 +96,29 @@ def get_or_activate_member(email, send_fn):
             "[deduplicate](https://protohaven.org/wiki/software/membership_validation)"
         )
         log.info("Notified of multiple accounts")
-    elif len(mm) == 0:
-        return None
+
+    m = None
     for m in mm:
         for acf in (m.get("individualAccount") or {}).get("accountCustomFields", []):
-            if acf['name'] == 'Account Automation Ran' and acf['value'].startswith("deferred"):
-
+            if acf["name"] == "Account Automation Ran" and acf["value"].startswith(
+                "deferred"
+            ):
                 send_fn("Activating membership...", 50)
-                rep = neon.set_membership_start_date(m['Account ID'], tznow())
+                rep = neon.set_membership_start_date(m["Account ID"], tznow())
                 if rep.status_code != 200:
                     send_membership_automation_message(
-                        f"@Staff: Error {rep.status_code} activating membership for #{m['Account ID']}: "
+                        f"@Staff: Error {rep.status_code} activating membership for "
+                        f"#{m['Account ID']}: "
                         f"\n{rep.content}\n"
                         "Please sync with software folks to diagnose in protohaven_api. "
                         "Allowing the member through anyways."
                     )
-                neon.update_account_automation_run_status(m['Account ID'], "activated")
+                neon.update_account_automation_run_status(m["Account ID"], "activated")
                 return m
-        if (
-            m.get("Account Current Membership Status") or ""
-        ).upper() == "ACTIVE":
+        if (m.get("Account Current Membership Status") or "").upper() == "ACTIVE":
             return m
     return m
+
 
 def welcome_sock(ws):  # pylint: disable=too-many-branches,too-many-statements
     """Websocket for handling front desk sign-in process. Status is reported back periodically"""
@@ -136,7 +137,7 @@ def welcome_sock(ws):  # pylint: disable=too-many-branches,too-many-statements
 
     if data["person"] == "member":
         _send("Searching member database...", 40)
-        m = get_or_activate_member(data['email'], ws.send)
+        m = get_or_activate_member(data["email"], ws.send)
 
         log.info(f"Member {m}")
         if not m:

--- a/protohaven_api/handlers/index_test.py
+++ b/protohaven_api/handlers/index_test.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 from protohaven_api.handlers import index
+from protohaven_api.integrations import neon
 from protohaven_api.main import app
 from protohaven_api.rbac import set_rbac
 
@@ -348,5 +349,52 @@ def test_welcome_signin_with_notify_board_and_staff(mocker):
         "@Board and @Staff: [First (foo@bar.com)](https://protohaven.app.neoncrm.com/admin/accounts/12345) just signed in at the front desk with `Notify Board & Staff = On Sign In`. This indicator suggests immediate followup with this member is needed. Click the name/email link for notes in Neon CRM."
     )
 
-def test_get_or_activate_member(mocker):
-    raise NotImplemented()
+def test_get_or_activate_multiple_accounts(mocker):
+    """Test if multiple accounts are found"""
+    mocker.patch.object(neon, "search_member", return_value=[
+        {"Account ID": "1", "Company ID": "2"},
+        {"Account ID": "3", "Company ID": "4"}
+    ])
+    mock_send_membership_automation_message = mocker.patch.object(index, "send_membership_automation_message")
+    result = index.get_or_activate_member("a@b.com", mocker.MagicMock())
+    mock_send_membership_automation_message.assert_called_once()
+
+def test_get_or_activate_deferred(mocker):
+    """Test if account automation is deferred"""
+    mocker.patch.object(neon, "search_member", return_value=[
+        {
+            "Account ID": "1",
+            "Company ID": "2",
+            "individualAccount": {
+                "accountCustomFields": [
+                    {"name": "Account Automation Ran", "value": "deferred"}
+                ]
+            }
+        }
+    ])
+    mock_set_membership_start_date = mocker.patch.object(neon, "set_membership_start_date", return_value=mocker.Mock(status_code=200))
+    mock_update_account_automation_run_status = mocker.patch.object(neon, "update_account_automation_run_status")
+    
+    result = index.get_or_activate_member("a@b.com", mocker.MagicMock())
+    assert result == neon.search_member.return_value[0]
+    mock_set_membership_start_date.assert_called_once()
+    mock_update_account_automation_run_status.assert_called_once_with("1", "activated")
+
+def test_get_or_activate_active_membership(mocker):
+    """Test if account is already active"""
+    mocker.patch.object(neon, "search_member", return_value=[
+        {
+            "Account ID": "1",
+            "Company ID": "2",
+            "Account Current Membership Status": "ACTIVE"
+        }
+    ])
+    
+    result = index.get_or_activate_member("a@b.com", mocker.MagicMock())
+    assert result == neon.search_member.return_value[0]
+
+def test_get_or_activate_no_accounts(mocker):
+    """Test if no accounts are found"""
+    mocker.patch.object(neon, "search_member", return_value=[])
+    result = index.get_or_activate_member("a@b.com", mocker.MagicMock())
+    assert result is None

--- a/protohaven_api/handlers/index_test.py
+++ b/protohaven_api/handlers/index_test.py
@@ -347,3 +347,6 @@ def test_welcome_signin_with_notify_board_and_staff(mocker):
     index.send_membership_automation_message.assert_called_with(
         "@Board and @Staff: [First (foo@bar.com)](https://protohaven.app.neoncrm.com/admin/accounts/12345) just signed in at the front desk with `Notify Board & Staff = On Sign In`. This indicator suggests immediate followup with this member is needed. Click the name/email link for notes in Neon CRM."
     )
+
+def test_get_or_activate_member(mocker):
+    raise NotImplemented()

--- a/protohaven_api/handlers/instructor.py
+++ b/protohaven_api/handlers/instructor.py
@@ -92,7 +92,7 @@ def get_instructor_readiness(inst, caps=None):
         result["active_membership"] = inst["Account Current Membership Status"]
     if inst.get("Discord User"):
         result["discord_user"] = "OK"
-    result["fullname"] = f"{inst['First Name']} {inst['Last Name']}".strip()
+    result["fullname"] = f"{inst['First Name'].strip()} {inst['Last Name'].strip()}".strip()
 
     if not caps:
         caps = airtable.fetch_instructor_capabilities(result["fullname"])

--- a/protohaven_api/handlers/instructor_test.py
+++ b/protohaven_api/handlers/instructor_test.py
@@ -254,7 +254,7 @@ def test_get_instructor_readiness_all_ok(mocker):
                 "Account ID": 12345,
                 "Account Current Membership Status": "Active",
                 "Discord User": "discord_user",
-                "First Name": "First",
+                "First Name": "First     ", # Egregious space in the name doesn't cause lookup error
                 "Last Name": "Last",
             }
         ]

--- a/protohaven_api/integrations/data/neon.py
+++ b/protohaven_api/integrations/data/neon.py
@@ -27,6 +27,7 @@ class CustomField:
     ZERO_COST_OK_UNTIL = 159
     PRONOUNS = 161
     NOTIFY_BOARD_AND_STAFF = 162
+    ACCOUNT_AUTOMATION_RAN = 163
 
     @classmethod
     def from_id(cls, v):

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -237,7 +237,7 @@ def set_membership_start_date(user_id, d):
         raise RuntimeError(f"No latest membership for member {user_id}")
 
     data = {
-        "termStartDate": start.strftime("%Y-%m-%d"),
+        "termStartDate": d.strftime("%Y-%m-%d"),
     }
     return get_connector().neon_request(
         cfg("api_key2"),

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -223,6 +223,31 @@ def set_custom_field(user_id, data):
     )
 
 
+def set_membership_start_date(user_id, d):
+    """Sets the termStartDate of the most recent membership of a user.
+        Recency is determined by its termStartDate."""
+    latest = (None, None)
+    for m in fetch_memberships(user_id):
+        log.info(str(m))
+        tsd = dateparser.parse(m['Term Start Date']).astimezone(tz)
+        if not latest[1] or latest[1] < tsd:
+            latest = (m['Membership ID'], tsd)
+
+    if not latest[0]:
+        raise RuntimeError(f"No latest membership for member {user_id}")
+
+    data = {
+        "termStartDate": start.strftime("%Y-%m-%d"),
+    }
+    return get_connector().neon_request(
+        cfg("api_key2"),
+        f"{URL_BASE}/memberships/{latest[0]}",
+        "PATCH",
+        body=json.dumps(data),
+        headers={"content-type": "application/json"},
+    )
+
+
 def set_interest(user_id, interest: str):
     """Assign interest to user custom field"""
     return set_custom_field(user_id, {"id": CustomField.INTEREST, "value": interest})
@@ -419,6 +444,31 @@ def get_members_with_role(role, extra_fields):
     }
     return _paginated_account_search(data)
 
+
+def get_new_members_needing_setup(created_after, extra_fields=None):
+    """Fetch all members in need of automated setup"""
+    if not extra_fields:
+        extra_fields = []
+    data = {
+        "searchFields": [
+            {
+                "field": str(CustomField.ACCOUNT_AUTOMATION_RAN),
+                "operator": "BLANK",
+            },
+            { # TODO enable
+                "field": "Account Created Date",
+                "operator": "GREATER_THAN",
+                "value": created_after.strftime("%Y-%m-%d"),
+            },
+            { # TODO remove
+                "field": "Account Current Membership Status",
+                "operator": "EQUAL",
+                "value": "Active",
+            },
+        ],
+        "outputFields": ["Account ID", "First Name", "Last Name", *extra_fields],
+    }
+    return _paginated_account_search(data)
 
 def get_members_with_discord_id(discord_id, extra_fields=None):
     """Fetch all members with a specific Discord ID"""
@@ -1104,6 +1154,14 @@ def update_announcement_status(user_id, now=None):
         user_id, {CustomField.ANNOUNCEMENTS_ACKNOWLEDGED: now.strftime("%Y-%m-%d")}
     )
 
+
+def update_account_automation_run_status(user_id, status:str, now=None):
+    """Updates automation ran timestamp"""
+    if now is None:
+        now = tznow()
+    return _set_custom_singleton_fields(
+        user_id, {CustomField.ACCOUNT_AUTOMATION_RAN: status + ' ' + now.strftime("%Y-%m-%d")}
+    )
 
 def update_waiver_status(  # pylint: disable=too-many-arguments
     user_id,

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -225,13 +225,13 @@ def set_custom_field(user_id, data):
 
 def set_membership_start_date(user_id, d):
     """Sets the termStartDate of the most recent membership of a user.
-        Recency is determined by its termStartDate."""
+    Recency is determined by its termStartDate."""
     latest = (None, None)
     for m in fetch_memberships(user_id):
         log.info(str(m))
-        tsd = dateparser.parse(m['Term Start Date']).astimezone(tz)
+        tsd = dateparser.parse(m["Term Start Date"]).astimezone(tz)
         if not latest[1] or latest[1] < tsd:
-            latest = (m['Membership ID'], tsd)
+            latest = (m["Membership ID"], tsd)
 
     if not latest[0]:
         raise RuntimeError(f"No latest membership for member {user_id}")
@@ -455,20 +455,16 @@ def get_new_members_needing_setup(created_after, extra_fields=None):
                 "field": str(CustomField.ACCOUNT_AUTOMATION_RAN),
                 "operator": "BLANK",
             },
-            { # TODO enable
+            {
                 "field": "Account Created Date",
                 "operator": "GREATER_THAN",
                 "value": created_after.strftime("%Y-%m-%d"),
-            },
-            { # TODO remove
-                "field": "Account Current Membership Status",
-                "operator": "EQUAL",
-                "value": "Active",
             },
         ],
         "outputFields": ["Account ID", "First Name", "Last Name", *extra_fields],
     }
     return _paginated_account_search(data)
+
 
 def get_members_with_discord_id(discord_id, extra_fields=None):
     """Fetch all members with a specific Discord ID"""
@@ -1155,13 +1151,15 @@ def update_announcement_status(user_id, now=None):
     )
 
 
-def update_account_automation_run_status(user_id, status:str, now=None):
+def update_account_automation_run_status(user_id, status: str, now=None):
     """Updates automation ran timestamp"""
     if now is None:
         now = tznow()
     return _set_custom_singleton_fields(
-        user_id, {CustomField.ACCOUNT_AUTOMATION_RAN: status + ' ' + now.strftime("%Y-%m-%d")}
+        user_id,
+        {CustomField.ACCOUNT_AUTOMATION_RAN: status + " " + now.strftime("%Y-%m-%d")},
     )
+
 
 def update_waiver_status(  # pylint: disable=too-many-arguments
     user_id,

--- a/protohaven_api/integrations/neon_test.py
+++ b/protohaven_api/integrations/neon_test.py
@@ -199,8 +199,14 @@ def test_set_event_scheduled_state(mocker):
         }
     )
 
-def test_membership_start_date():
+def test_set_membership_start_date():
     raise NotImplemented()
 
-def test_membership_start_date_no_memberships():
+def test_set_membership_start_date_no_memberships():
+    raise NotImplemented()
+
+def test_update_account_automation_run_status():
+    raise NotImplemented()
+
+def test_paginated_account_search():
     raise NotImplemented()

--- a/protohaven_api/integrations/neon_test.py
+++ b/protohaven_api/integrations/neon_test.py
@@ -198,3 +198,9 @@ def test_set_event_scheduled_state(mocker):
             "enableWaitListing": False,
         }
     )
+
+def test_membership_start_date():
+    raise NotImplemented()
+
+def test_membership_start_date_no_memberships():
+    raise NotImplemented()


### PR DESCRIPTION
See https://docs.google.com/document/d/1O8qsvyWyVF7qY0cBQTNUcT60DdfMaLGg8FUDQdciivM/edit

* Adds `ACCOUNT_AUTOMATION_RAN` neon custom field to track the progress of account creation automation.
* Adds `init_new_memberships` CLI command which defers memberships indefinitely until they've signed in at the front desk. 
  * Also creates a coupon and sends an introductory email, with a best-effort list of upcoming classes with empty seats that would be free given the coupon's price.
* Refactors initial member search on the `/welcome` page sign-in process; if the account was deferred, start the membership & mark it as activated.

The setup of the  `ACCOUNT_AUTOMATION_RAN` leaves room for future shenanigans, e.g. "send email X days after first sign in reminding about equipment reservation", "send reminder to join Discord" etc.