### PR TITLE
Upgrade class scheduler to respect multi-day classes

### DIFF
--- a/protohaven_api/automation/classes/scheduler.py
+++ b/protohaven_api/automation/classes/scheduler.py
@@ -205,7 +205,7 @@ def generate_env(
 
     # Load classes from airtable
     classes = list(load_schedulable_classes(exclusions))
-    class_by_id = {cls.airtable_id: cls for cls in classes}
+    class_by_id = {cls.class_id: cls for cls in classes}
     log.info(f"Loaded {len(classes)} classes")
 
     instructors = []
@@ -258,7 +258,7 @@ def generate_env(
 
     log.info(f"All capabilities: {all_inst_caps}")
     return {
-        "classes": [c.as_dict() for c in classes if c.airtable_id in all_inst_caps],
+        "classes": [c.as_dict() for c in classes if c.class_id in all_inst_caps],
         "instructors": [i.as_dict() for i in instructors],
         "area_occupancy": dict(
             area_occupancy.items()

--- a/protohaven_api/automation/classes/solver.py
+++ b/protohaven_api/automation/classes/solver.py
@@ -99,11 +99,14 @@ class Instructor:
 
 
 def _find_overlap(c1, t1, c2, t2):
+    """Expand two classes starting at two times and return
+    True if they overlap
+    """
     for c1t0, c1t1 in c1.expand(t1):
         for c2t0, c2t1 in c2.expand(t2):
             if date_range_overlaps(c1t0, c1t1, c2t0, c2t1):
-                return t2
-    return None
+                return True
+    return False
 
 
 def get_overlapping(c1, t1, classes, times):
@@ -112,13 +115,11 @@ def get_overlapping(c1, t1, classes, times):
     Note that duplicate values may be returned."""
     for c2 in classes:
         # Classes without intersecting areas don't have a chance of overlapping
-        if len(set(c1.areas).intersection(c2.areas)) == 0:
+        if len(set(c1.areas).intersection(set(c2.areas))) == 0:
             continue
         for t2 in times:
-            ovr = _find_overlap(c1, t1, c2, t2)
-            print("Test ", c2, t2, ovr)
-            if ovr is not None:
-                yield c2.class_id, ovr
+            if _find_overlap(c1, t1, c2, t2):
+                yield c2.class_id, t2
 
 
 def solve(classes, instructors):  # pylint: disable=too-many-locals,too-many-branches

--- a/protohaven_api/automation/classes/solver_test.py
+++ b/protohaven_api/automation/classes/solver_test.py
@@ -86,6 +86,18 @@ def test_solve_simple():
     assert score == 0.7
 
 
+def test_solve_prefer_earlier():
+    """Given the same class at two times, the earlier one is scheduled"""
+    c = s.Class(
+        1, "Embroidery", days=1, hours=1, areas=["textiles"], exclusions=[], score=0.7
+    )
+    got, _ = s.solve(
+        classes=[c],
+        instructors=[s.Instructor("A", {c.class_id: [d(2), d(0), d(1)]})],
+    )
+    assert got == {"A": [[1, "Embroidery", d(0).isoformat()]]}
+
+
 def test_solve_complex():
     """Run an example set of classes and instructors through the solver; assert no exceptions"""
     classes = [

--- a/protohaven_api/automation/classes/solver_test.py
+++ b/protohaven_api/automation/classes/solver_test.py
@@ -1,18 +1,67 @@
 """Test behavior of linear solver for class scheduling"""
 
+from collections import namedtuple
+
+import pytest
 
 from protohaven_api.automation.classes import (
     solver as s,  # pylint: disable=import-error
 )
-from protohaven_api.testing import d
+from protohaven_api.testing import d, idfn
+
+Tc = namedtuple("tc", "desc,t,a,want")
+
+
+@pytest.mark.parametrize(
+    "tc",
+    [
+        Tc(
+            "basic",
+            d(0),
+            "textiles",
+            [
+                ("AE", d(0)),
+                ("SB", d(0)),
+            ],
+        ),
+        Tc(
+            "prev runs also included",
+            d(14),
+            "textiles",
+            [
+                ("AE", d(0)),
+                ("AE", d(7)),
+                ("AE", d(14)),
+                ("SB", d(14)),
+            ],
+        ),
+    ],
+    ids=idfn,
+)
+def test_class_starts_intersecting_time_and_area(tc):
+    """Testing various scenarios of classes overlapping one another"""
+    classes = [
+        s.Class(cid, name, hours, days, areas, exclusions=[], score=1)
+        for cid, name, hours, days, areas in [
+            ("AE", "Advanced embroidery", 3, 3, ["textiles"]),
+            ("SB", "Sewing Basics", 3, 1, ["textiles"]),
+            ("BW", "Basic Woodshop", 2, 1, ["wood"]),
+        ]
+    ]
+    times = [d(0), d(7), d(14)]
+    assert set(
+        s.class_starts_intersecting_time_and_area(tc.t, tc.a, times, classes)
+    ) == set(tc.want)
 
 
 def test_solve_simple():
     """An instructor can schedule a class at a time"""
-    c = s.Class(1, "Embroidery", 1, ["textiles"], [], 0.7)
+    c = s.Class(
+        1, "Embroidery", days=1, hours=1, areas=["textiles"], exclusions=[], score=0.7
+    )
     got, score = s.solve(
         classes=[c],
-        instructors=[s.Instructor("A", {c.airtable_id: [d(0)]})],
+        instructors=[s.Instructor("A", {c.class_id: [d(0)]})],
     )
     assert got == {"A": [[1, "Embroidery", d(0).isoformat()]]}
     assert score == 0.7
@@ -23,12 +72,12 @@ def test_solve_complex():
     classes = [
         s.Class(*v)
         for v in [
-            (1, "Embroidery", 1, ["textiles"], [], 0.7),
-            (2, "Sewing Basics", 2, ["textiles"], [], 0.6),
-            (3, "Basic Woodshop", 2, ["wood"], [], 0.5),
-            (4, "Millwork", 1, ["wood"], [], 0.7),
-            (5, "Basic Metals", 2, ["metal"], [], 0.8),
-            (6, "Metal Workshop", 1, ["metal"], [], 0.4),
+            (1, "Embroidery", 1, 1, ["textiles"], [], 0.7),
+            (2, "Sewing Basics", 2, 1, ["textiles"], [], 0.6),
+            (3, "Basic Woodshop", 2, 1, ["wood"], [], 0.5),
+            (4, "Millwork", 1, 1, ["wood"], [], 0.7),
+            (5, "Basic Metals", 2, 1, ["metal"], [], 0.8),
+            (6, "Metal Workshop", 1, 1, ["metal"], [], 0.4),
         ]
     ]
 
@@ -38,14 +87,14 @@ def test_solve_complex():
             (
                 "A",
                 {
-                    classes[c].airtable_id: [d(i) for i in [1, 7, 14, 21, 29]]
+                    classes[c].class_id: [d(i) for i in [1, 7, 14, 21, 29]]
                     for c in (0, 1)
                 },
             ),
             (
                 "B",
                 {
-                    classes[c].airtable_id: [
+                    classes[c].class_id: [
                         d(i) for i in [1, 4, 5, 8, 11, 14, 22, 25, 29]
                     ]
                     for c in (2, 0, 3)
@@ -53,12 +102,9 @@ def test_solve_complex():
             ),
             (
                 "C",
-                {
-                    classes[c].airtable_id: [d(i) for i in [5, 7, 2, 1]]
-                    for c in (4, 5, 0)
-                },
+                {classes[c].class_id: [d(i) for i in [5, 7, 2, 1]] for c in (4, 5, 0)},
             ),
-            ("D", {classes[c].airtable_id: [d(i) for i in range(30)] for c in (3, 1)}),
+            ("D", {classes[c].class_id: [d(i) for i in range(30)] for c in (3, 1)}),
         ]
     ]
 
@@ -72,8 +118,8 @@ def test_solve_no_concurrent_overlap():
     when scheduled concurrently. Higher score classes win."""
     got, score = s.solve(
         classes=[
-            s.Class(1, "Embroidery", 1, ["textiles"], [], 0.7),
-            s.Class(2, "Embroidery but cooler", 1, ["textiles"], [], 0.8),
+            s.Class(1, "Embroidery", 1, 1, ["textiles"], [], 0.7),
+            s.Class(2, "Embroidery but cooler", 1, 1, ["textiles"], [], 0.8),
         ],
         instructors=[
             s.Instructor("A", {1: [d(0)]}),
@@ -89,8 +135,8 @@ def test_solve_no_double_booking():
     Higher score classes should be preferred"""
     got, score = s.solve(
         classes=[
-            s.Class(1, "Embroidery", 1, ["textiles"], [], 0.7),
-            s.Class(2, "Lasers", 1, ["lasers"], [], 0.8),
+            s.Class(1, "Embroidery", 1, 1, ["textiles"], [], 0.7),
+            s.Class(2, "Lasers", 1, 1, ["lasers"], [], 0.8),
         ],
         instructors=[
             s.Instructor("A", {1: [d(0)], 2: [d(0)]}),
@@ -104,7 +150,7 @@ def test_solve_at_most_once():
     """Classes run at most once per run of the solver"""
     got, score = s.solve(
         classes=[
-            s.Class(1, "Embroidery", 1, ["textiles"], [], 0.7),
+            s.Class(1, "Embroidery", 1, 1, ["textiles"], [], 0.7),
         ],
         instructors=[
             s.Instructor("A", {1: [d(0)]}),

--- a/protohaven_api/automation/classes/validation.py
+++ b/protohaven_api/automation/classes/validation.py
@@ -1,5 +1,6 @@
 """Provide date and availability validation methods for class scheduling"""
 import datetime
+from functools import reduce
 
 import holidays
 
@@ -57,8 +58,10 @@ def date_within_exclusions(d, exclusions):
 us_holidays = holidays.US()  # pylint: disable=no-member
 
 
-def validate_candidate_class_time(c, t0, inst_occupancy, area_occupancy):
-    """Ensure solver.Class `c` being taught at datetime t0 is not invalid for reasons e.g.
+def validate_candidate_class_time(  # pylint: disable=too-many-return-statements, too-many-locals
+    c, start, inst_occupancy, area_occupancy, avail
+):
+    """Ensure solver.Class `c` being taught at `start` is not invalid for reasons e.g.
     - Scheduled on a US holiday
     - On the same day as instructor is already teaching (`inst_occupancy`)
     - In an area that's already reserved for something else (`area_occupancy`)
@@ -67,36 +70,50 @@ def validate_candidate_class_time(c, t0, inst_occupancy, area_occupancy):
     if c is None or c.hours is None:
         return False, "Could not fetch class timing details"
 
-    # Note: We'll want to handle multi-day classes (intensives) eventually
-    t1 = t0 + datetime.timedelta(hours=c.hours)
+    for session in range(c.days):
+        t0 = start + datetime.timedelta(days=7 * session)
+        t1 = t0 + datetime.timedelta(hours=c.hours)
 
-    # Skip holiday classes
-    if t0 in us_holidays:
-        return False, "Occurs on a US holiday"
-
-    # Skip if instructor is already busy on this day
-    for occ in inst_occupancy:
-        if t0.date() == occ[0].date():
+        # Make sure the instructor is available
+        within_avail = reduce(
+            lambda a, b: a or b, [t0 >= a0 and t1 <= a1 for a0, a1 in avail], False
+        )
+        if not within_avail:
             return (
                 False,
-                f"Same day as another class being taught by instructor ({occ[2]})",
+                f"Day {session+1} ({t0} - {t1}) does not fall within instructor availability",
             )
 
-    # Skip if area is already occupied
-    for a in c.areas:
-        conflicting_class = has_area_conflict(area_occupancy.get(a, []), t0, t1)
-        if conflicting_class:
-            return False, f"Area already occupied by other event ({conflicting_class})"
+        # Skip holiday classes
+        if t0 in us_holidays:
+            return False, "Occurs on a US holiday"
 
-    # Skip this particular time if it's in an exclusion region
-    excluding_class_dates = date_within_exclusions(t0, c.exclusions)
-    if excluding_class_dates:
-        e1, e2, esched = excluding_class_dates
-        return (
-            False,
-            f"Too soon before/after same class (scheduled for "
-            f"{esched.strftime('%Y-%m-%d')}; no repeats allowed "
-            f"between {e1.strftime('%Y-%m-%d')} and {e2.strftime('%Y-%m-%d')})",
-        )
+        # Skip if instructor is already busy on this day
+        for occ in inst_occupancy:
+            if t0.date() == occ[0].date():
+                return (
+                    False,
+                    f"Same day as another class being taught by instructor ({occ[2]})",
+                )
+
+        # Skip if area is already occupied
+        for a in c.areas:
+            conflicting_class = has_area_conflict(area_occupancy.get(a, []), t0, t1)
+            if conflicting_class:
+                return (
+                    False,
+                    f"Area already occupied by other event ({conflicting_class})",
+                )
+
+        # Skip this particular time if it's in an exclusion region
+        excluding_class_dates = date_within_exclusions(t0, c.exclusions)
+        if excluding_class_dates:
+            e1, e2, esched = excluding_class_dates
+            return (
+                False,
+                f"Too soon before/after same class (scheduled for "
+                f"{esched.strftime('%Y-%m-%d')}; no repeats allowed "
+                f"between {e1.strftime('%Y-%m-%d')} and {e2.strftime('%Y-%m-%d')})",
+            )
 
     return True, None

--- a/protohaven_api/automation/classes/validation.py
+++ b/protohaven_api/automation/classes/validation.py
@@ -1,5 +1,4 @@
 """Provide date and availability validation methods for class scheduling"""
-import datetime
 from functools import reduce
 
 import holidays
@@ -70,10 +69,7 @@ def validate_candidate_class_time(  # pylint: disable=too-many-return-statements
     if c is None or c.hours is None:
         return False, "Could not fetch class timing details"
 
-    for session in range(c.days):
-        t0 = start + datetime.timedelta(days=7 * session)
-        t1 = t0 + datetime.timedelta(hours=c.hours)
-
+    for t0, t1 in c.expand(start):
         # Make sure the instructor is available
         within_avail = reduce(
             lambda a, b: a or b, [t0 >= a0 and t1 <= a1 for a0, a1 in avail], False
@@ -81,7 +77,7 @@ def validate_candidate_class_time(  # pylint: disable=too-many-return-statements
         if not within_avail:
             return (
                 False,
-                f"Day {session+1} ({t0} - {t1}) does not fall within instructor availability",
+                f"Class time ({t0} - {t1}) does not fall within instructor availability",
             )
 
         # Skip holiday classes

--- a/protohaven_api/automation/classes/validation_test.py
+++ b/protohaven_api/automation/classes/validation_test.py
@@ -91,7 +91,7 @@ Tc = namedtuple("tc", tuple(fields.keys()), defaults=tuple(fields.values()))
             avail=[(d(20), d(21)), (d(27), d(28))],
             class_days=3,
             want_reason=(
-                "Day 3 (2025-02-04 00:00:00-05:00 - 2025-02-04 03:00:00-05:00) "
+                "Class time (2025-02-04 00:00:00-05:00 - 2025-02-04 03:00:00-05:00) "
                 "does not fall within instructor availability"
             ),
         ),

--- a/svelte/src/lib/dashboard/scheduler.svelte
+++ b/svelte/src/lib/dashboard/scheduler.svelte
@@ -61,8 +61,8 @@
       let cls_ids = new Set(Object.keys(candidates) || []);
       classes = {};
       for (let cls of data.classes) {
-        if (cls_ids.has(cls.airtable_id)) {
-          classes[cls.airtable_id] = {name: cls.name, checked: true};
+        if (cls_ids.has(cls.class_id)) {
+          classes[cls.class_id] = {name: cls.name, checked: true};
         }
       }
     });

--- a/svelte/src/routes/+page.ts
+++ b/svelte/src/routes/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true; // For static pages


### PR DESCRIPTION
This was a two-part fix:

1. Plumb through `Class.hours` everywhere that a 3-hour class is assumed
2. For every combination of `(class, instructor, time)`, ensure that multi-day classes that ran *before* `time` but also that happen to overlap are taken into account. 

Also did a bulk rename of `c.airtable_id` to `c.class_id` as it's a little more descriptive.

Additionally added a small penalty to the score the farther out a class is from running - the scheduler now prefers to schedule a class sooner.