### PR TITLE
Convert to OAuth2 gmail API; refactor send_comms

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -97,10 +97,13 @@ airtable:
     sign_ins: "tblVBhzeE3k9yYRn9"
     automation_intents: "tblBgXQlOFjNqvBVm"
 calendar:
-  # Access to calendars requires `credentials.json`
+  credentials_path: "credentials.json"
   instructor_schedules: "c_ab048e21805a0b5f7f094a81f6dbd19a3cba5565b408962565679cd48ffd02d9@group.calendar.google.com"
   shop_events: "workshop@protohaven.org"
   scopes: ["https://www.googleapis.com/auth/calendar.readonly"]
+gmail: # See protohaven_api.integrations.data.connector, Connector.email() for details
+  credentials_path: "credentials.json"
+  scopes: ["https://www.googleapis.com/auth/gmail.send"]
 square:
   sandbox_app_id: "sandbox-sq0idb-sUaoKt-N2lB7_geQO-cgjg"
   sandbox_token: "EAAAEGKUuR67gUfi0Hmfq5dfn8nSiuhibpB2HSDQTlAzQbaCQCEcJ6uPUJjcyAcm" # pragma: allowlist secret
@@ -134,7 +137,7 @@ asana:
   tech_ready_tag: "1205552792690050"
   custom_field_airtable_id: "1206525862874335"
 sheets:
-  # Access to sheets requires `credentials.json`
+  credentials_path: "credentials.json"
   instructor_hours: "1dM_b1O7Uzj4qwyyJ-uMTmrE6sIcWowYnzYxhhpcWbGI" # pragma: allowlist secret
   welcome_waiver_form: "1UrLZV1uAxW4ziLdy02kSXg15jidRYpktgQP8D5qz2rU" # pragma: allowlist secret
   scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"]

--- a/protohaven_api/integrations/schedule.py
+++ b/protohaven_api/integrations/schedule.py
@@ -26,7 +26,7 @@ def fetch_calendar(calendar_id, time_min=None, time_max=None):
     time_max = time_max.isoformat() + "Z"  # 'Z' indicates UTC time
 
     creds = service_account.Credentials.from_service_account_file(
-        "credentials.json", scopes=get_config("calendar/scopes")
+        get_config("calendar/credentials_path"), scopes=get_config("calendar/scopes")
     )
     service = build("calendar", "v3", credentials=creds)
     # Call the Calendar API

--- a/protohaven_api/integrations/sheets.py
+++ b/protohaven_api/integrations/sheets.py
@@ -14,11 +14,12 @@ def get_sheet_range(sheet_id, range_name):
     """Shows basic usage of the Sheets API.
     Prints values from a sample spreadsheet.
     The usual credentials.json uses protohaven-cli@
-    protohaven-api.iam.gserviceaccount.com service account;
-    this account must have read access for the call to succeed.
+    protohaven-api.iam.gserviceaccount.com service account,
+    managed by the `workshop` account.
+    This account must have read access for the call to succeed.
     """
     creds = service_account.Credentials.from_service_account_file(
-        "credentials.json", scopes=get_config("sheets/scopes")
+        get_config("sheets/credentials_path"), scopes=get_config("sheets/scopes")
     )
     service = build("sheets", "v4", credentials=creds)
     # Call the Sheets API

--- a/protohaven_api/scripts/transfer_gcal_to_airtable.py
+++ b/protohaven_api/scripts/transfer_gcal_to_airtable.py
@@ -27,7 +27,7 @@ def fetch_calendar(calendar_id, time_min=None, time_max=None):
     time_max = time_max.isoformat() + "Z"  # 'Z' indicates UTC time
 
     creds = service_account.Credentials.from_service_account_file(
-        "credentials.json", scopes=get_config("calendar/scopes")
+        get_config("calendar/credentials_path"), scopes=get_config("calendar/scopes")
     )
     service = build("calendar", "v3", credentials=creds)
     # Call the Calendar API


### PR DESCRIPTION
Google's turning down their "less secure authentication" access method for sending emails. Happening "Fall 2024", so we need to switch to using OAuth2 and the google API's python module.

https://support.google.com/a/answer/14114704?sjid=4265311194558355625-NA

Also includes some refactors to push credential path for google APIs into config.yaml, also splits send_comms into separate helpers for discord & email.