### PR TITLE
Onboarding v2, Booked sync upgrades, tech tabs upgrade, general cleanup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -152,6 +152,24 @@ booked:
     area: 2
     tool_code: 3
     clearance_code: 4
+  members_group_id: 12
+  tool_type_id: 8
+  schedule_id: 1
+  base_url: "https://reserve.protohaven.org/Web/Services/" # Must end in slash to be appended to
+  exclude_areas:
+  - "Class Supplies"
+  - "Maintenance"
+  - "Staff Room"
+  - "Back Yard"
+  - "Fishbowl"
+  - "Maker Market"
+  - "Rack Storage"
+  - "Restroom 1"
+  - "Restroom 2"
+  - "Kitchen"
+  - "Gallery"
+  - "Custodial Room"
+  - "All"
 wiki:
   user: "${WIKI_USER}"
   password: "${WIKI_PASSWORD}"

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,8 @@ openai:
   api_key: "${OPENAI_API_KEY}"
 neon:
   domain: "protohaven"
+  base_url: "https://api.neoncrm.com/v2/"
+  admin_url: "https://protohaven.app.neoncrm.com/np/admin/"
   oauth_client_id: "${NEON_OAUTH_CLIENT_ID}"
   oauth_client_secret: "${NEON_OAUTH_CLIENT_SECRET}"
   api_key1: "${NEON_API_KEY1}"

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 general:
   log_level: "${LOGLEVEL}"
+  yaml_out: "${YAML_OUT}"
   server_mode: "${PH_SERVER_MODE}"
   behind_proxy: false
   cors: "${CORS}"

--- a/protohaven_api/automation/classes/builder.py
+++ b/protohaven_api/automation/classes/builder.py
@@ -55,11 +55,11 @@ def gen_class_scheduled_alerts(scheduled_by_instructor):
     def format_class(cls, inst=False):
         start = dateparser.parse(cls["fields"]["Start Time"])
         start = start.astimezone(tz)
-        # print(cls)
-        result = f"- {start.strftime('%b %d %Y, %-I%P')}: {cls['fields']['Name (from Class)'][0]}"
-        if inst:
-            result += f" ({cls['fields']['Instructor']})"
-        return result
+        return {
+            "start": start.strftime("%b %d %Y, %-I%P"),
+            "name": cls["fields"]["Name (from Class)"][0],
+            "inst": cls["fields"]["Instructor"] if inst else None,
+        }
 
     details = {"action": ["SCHEDULE"], "targets": []}
     channel_class_list = []
@@ -86,7 +86,8 @@ def gen_class_scheduled_alerts(scheduled_by_instructor):
         results.append(
             Msg.tmpl(
                 "instructors_new_classes",
-                formatted=[format_class(c, inst=True) for c in channel_class_list],
+                n=len(channel_class_list),
+                classes=[format_class(c, inst=True) for c in channel_class_list],
                 target="#instructors",
             )
         )

--- a/protohaven_api/automation/membership/membership.py
+++ b/protohaven_api/automation/membership/membership.py
@@ -82,7 +82,9 @@ def init_membership(  # pylint: disable=too-many-arguments,inconsistent-return-s
     assert account_id and membership_id
     include_filter = get_config("neon/webhooks/new_membership/include_filter", None)
     if include_filter is not None and email not in include_filter:
-        log.info(f"Skipping init (no match in include_filter {include_filter})")
+        log.info(
+            f"Skipping membership init (no match in include_filter {include_filter})"
+        )
         return None
 
     log.info(f"Setting #{account_id} start date to {PLACEHOLDER_START_DATE}")

--- a/protohaven_api/automation/membership/sign_in.py
+++ b/protohaven_api/automation/membership/sign_in.py
@@ -70,14 +70,21 @@ def activate_membership(account_id, fname, email):
         log.error(f"activate_membership called on non-deferred account {account_id}")
         return
 
-    rep = neon.set_membership_date_range(
-        account_id, tznow(), tznow() + datetime.timedelta(days=30)
-    )
-    if rep.status_code != 200:
+    try:
+        membership_id = neon.get_latest_membership_id(account_id)
+        if not membership_id:
+            raise RuntimeError(
+                f"Could not fetch latest membership for account {account_id}"
+            )
+        log.info(f"Resolved account {account_id} latest membership ID {membership_id}")
+        neon.set_membership_date_range(
+            membership_id, tznow(), tznow() + datetime.timedelta(days=30)
+        )
+    except RuntimeError as e:
         notify_async(
-            f"@Staff: Error {rep.status_code} activating membership for "
+            f"@Staff: Error activating membership for "
             f"#{account_id}: "
-            f"\n{rep.content}\n"
+            f"\n{e}\n"
             "Please sync with software folks to diagnose in protohaven_api. "
             "Allowing the member through anyways."
         )
@@ -85,8 +92,12 @@ def activate_membership(account_id, fname, email):
 
     neon.update_account_automation_run_status(account_id, "activated")
     msg = comms.Msg.tmpl("membership_activated", fname=fname, target=email)
-    comms.send_email(msg.subject, msg.body, email, msg.html)
+    comms.send_email(msg.subject, msg.body, [email], msg.html)
     log.info(f"Sent email {msg}")
+    notify_async(
+        f"Activated deferred membership for {fname} ({email}, "
+        f"#{account_id}) as they've just signed in at the front desk"
+    )
 
 
 def submit_forms(form_data):
@@ -266,10 +277,10 @@ def as_member(data, send):
         _apply_async(
             activate_membership, args=(m["Account ID"], m["First Name"], data["email"])
         )
+        result["status"] = "Active"  # Assume the activation went through
+    else:
+        result["status"] = m.get("Account Current Membership Status", "Unknown")
 
-    # Preferably select the Neon account with active membership.
-    # Note that the last `m` remains in context regardless of if we break.
-    result["status"] = m.get("Account Current Membership Status", "Unknown")
     result["firstname"] = m.get("First Name")
     data["url"] = f"https://protohaven.app.neoncrm.com/admin/accounts/{m['Account ID']}"
 

--- a/protohaven_api/automation/membership/sign_in.py
+++ b/protohaven_api/automation/membership/sign_in.py
@@ -139,7 +139,9 @@ def get_member_and_activation_state(email):
     if len(mm) > 1:
         # Warn to membership automation channel that we have an account to deduplicate
         urls = [
-            f"  https://protohaven.app.neoncrm.com/admin/accounts/{m['Account ID']}"
+            f"  [#{m['Account ID']}]"
+            + f"(https://protohaven.app.neoncrm.com/admin/accounts/{m['Account ID']}) "
+            + f"{m.get('First Name')} {m.get('Last Name')} ({m.get('Email 1')})"
             for m in mm
         ]
         notify_async(

--- a/protohaven_api/automation/roles/roles.py
+++ b/protohaven_api/automation/roles/roles.py
@@ -6,7 +6,6 @@ from dataclasses import asdict, dataclass, replace
 
 from dateutil import parser as dateparser
 
-from protohaven_api.config import exec_details_footer
 from protohaven_api.integrations import airtable, comms, neon
 from protohaven_api.integrations.comms import Msg
 from protohaven_api.rbac import Role
@@ -347,7 +346,6 @@ def gen_role_comms(user_log, roles_assigned, roles_revoked):
             n=len(user_log),
             roles_assigned=roles_assigned,
             roles_revoked=roles_revoked,
-            footer=exec_details_footer(),
             target="#membership-automation",
         )
 

--- a/protohaven_api/cli.py
+++ b/protohaven_api/cli.py
@@ -16,7 +16,8 @@ from protohaven_api.commands import (
     roles,
     violations,
 )
-from protohaven_api.config import get_config, get_execution_log_link
+from protohaven_api.config import get_config
+from protohaven_api.integrations.cronicle import Progress
 from protohaven_api.integrations.data.connector import Connector
 from protohaven_api.integrations.data.connector import init as init_connector
 from protohaven_api.integrations.data.dev_connector import DevConnector
@@ -39,25 +40,6 @@ if get_config("discord_bot/enabled", as_bool=True):
     )  # Hacky - should use `wait_until_ready` but there's threading problems
 else:
     log.debug("Skipping startup of discord bot")
-
-
-class Progress:
-    """A simple progress reporter that allows for multiple stages/loops"""
-
-    def __init__(self, n=1, on=None):
-        self.on = on or (get_execution_log_link() is not None)
-        self.n = n
-
-    def set_stages(self, n):
-        """Set the number of stages of progress"""
-        self.n = n
-
-    def __setitem__(self, i, v):
-        """Writes progress to stdout for reading by Cronicle.
-        This is omitted if we're not running as a cronicle job."""
-        pct = f"{(v + i) / self.n:.2f}"
-        if self.on:
-            print('{ "progress": ' + pct + " }")
 
 
 class ProtohavenCLI(  # pylint: disable=too-many-ancestors

--- a/protohaven_api/cli.py
+++ b/protohaven_api/cli.py
@@ -16,7 +16,7 @@ from protohaven_api.commands import (
     roles,
     violations,
 )
-from protohaven_api.config import get_config
+from protohaven_api.config import get_config, get_execution_log_link
 from protohaven_api.integrations.data.connector import Connector
 from protohaven_api.integrations.data.connector import init as init_connector
 from protohaven_api.integrations.data.dev_connector import DevConnector
@@ -39,6 +39,25 @@ if get_config("discord_bot/enabled", as_bool=True):
     )  # Hacky - should use `wait_until_ready` but there's threading problems
 else:
     log.debug("Skipping startup of discord bot")
+
+
+class Progress:
+    """A simple progress reporter that allows for multiple stages/loops"""
+
+    def __init__(self, n=1, on=None):
+        self.on = on or (get_execution_log_link() is not None)
+        self.n = n
+
+    def set_stages(self, n):
+        """Set the number of stages of progress"""
+        self.n = n
+
+    def __setitem__(self, i, v):
+        """Writes progress to stdout for reading by Cronicle.
+        This is omitted if we're not running as a cronicle job."""
+        pct = f"{(v + i) / self.n:.2f}"
+        if self.on:
+            print('{ "progress": ' + pct + " }")
 
 
 class ProtohavenCLI(  # pylint: disable=too-many-ancestors
@@ -75,7 +94,7 @@ class ProtohavenCLI(  # pylint: disable=too-many-ancestors
             parser.print_help()
             sys.exit(1)
         getattr(self, args.command)(
-            sys.argv[2:]
+            sys.argv[2:], Progress()
         )  # Ignore first two argvs - already parsed
 
 

--- a/protohaven_api/commands/classes.py
+++ b/protohaven_api/commands/classes.py
@@ -51,7 +51,7 @@ class Commands:
             default=True,
         ),
     )
-    def gen_instructor_schedule_reminder(self, args):
+    def gen_instructor_schedule_reminder(self, args, _):
         """Reads the list of instructors from Airtable and generates
         reminder comms to all instructors, plus the #instructors discord,
         to propose additional class scheduling times"""
@@ -134,7 +134,7 @@ class Commands:
             default=True,
         ),
     )
-    def gen_class_emails(self, args):
+    def gen_class_emails(self, args, _):
         """Reads schedule of classes from Neon and Airtable and outputs
         a list of emails to send to instructors, techs, and students.
         This does not actually send the emails; for that, see send_comms."""
@@ -174,7 +174,7 @@ class Commands:
             required=True,
         ),
     )
-    def build_scheduler_env(self, args):
+    def build_scheduler_env(self, args, _):
         """Construct an environment for assigning classes at times to instructors"""
         start = dateparser.parse(args.start).astimezone(tz)
         end = dateparser.parse(args.end).astimezone(tz)
@@ -190,7 +190,7 @@ class Commands:
             required=True,
         )
     )
-    def run_scheduler(self, args):
+    def run_scheduler(self, args, _):
         """Run the class scheduler on a provided env"""
         env = load_yaml(args.path)
         instructor_classes, final_score = scheduler.solve_with_env(env[0])
@@ -211,7 +211,7 @@ class Commands:
             default=False,
         ),
     )
-    def append_schedule(self, args):
+    def append_schedule(self, args, _):
         """Adds a schedule (created with `run_scheduler`) to Airtable for
         instructor confirmation."""
         sched = load_yaml(args.path)[0]
@@ -228,7 +228,7 @@ class Commands:
             nargs="+",
         )
     )
-    def cancel_classes(self, args):
+    def cancel_classes(self, args, _):
         """cancel passed classes by unpublishing and disabling registration"""
         for i in args.id:
             i = i.strip()

--- a/protohaven_api/commands/classes.py
+++ b/protohaven_api/commands/classes.py
@@ -422,7 +422,7 @@ class Commands:
         ),
     )
     def post_classes_to_neon(
-        self, args
+        self, args, _
     ):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         """Post a list of classes to Neon"""
         log.info(

--- a/protohaven_api/commands/classes_test.py
+++ b/protohaven_api/commands/classes_test.py
@@ -30,8 +30,8 @@ def test_category_from_event_name():
     )
 
 
-@pytest.fixture
-def e(mocker):
+@pytest.fixture(name="e")
+def fixture_e(mocker):
     mocker.patch.object(C.airtable, "update_record")
     mocker.patch.object(C.neon, "set_event_scheduled_state")
     mocker.patch.object(C.neon, "assign_pricing")
@@ -40,8 +40,8 @@ def e(mocker):
     return C
 
 
-@pytest.fixture
-def cli(capsys):
+@pytest.fixture(name="cli")
+def fixture_cli(capsys):
     return mkcli(capsys, C)
 
 

--- a/protohaven_api/commands/comms.py
+++ b/protohaven_api/commands/comms.py
@@ -128,7 +128,7 @@ class Commands:  # pylint: disable=too-few-public-methods
             default=True,
         ),
     )
-    def send_comms(self, args):
+    def send_comms(self, args, _):
         """Reads a list of emails/discord messages and sends them to their recipients"""
         data = self._load_comms_data(args.path)
         if not data:

--- a/protohaven_api/commands/comms_test.py
+++ b/protohaven_api/commands/comms_test.py
@@ -6,13 +6,19 @@ from unittest.mock import call
 import pytest
 
 from protohaven_api.commands import comms as c
-from protohaven_api.testing import idfn
+from protohaven_api.testing import idfn, mkcli
 
 Tc = namedtuple(
     "Tc",
     "desc,data,args,email,log,discord,intents_notified,scheduled_state",
     defaults=[None for _ in range(7)],
 )
+
+
+@pytest.fixture(name="cli")
+def fixture_cli(capsys):
+    """Create CLI fixture"""
+    return mkcli(capsys, c)
 
 
 @pytest.mark.parametrize(
@@ -117,7 +123,7 @@ Tc = namedtuple(
     ],
     ids=idfn,
 )
-def test_send_comms(mocker, tc):
+def test_send_comms(mocker, tc, cli):
     """Tes comms sent without an id (most basic)"""
     mocker.patch.object(c.comms, "send_discord_message")
     mocker.patch.object(c.comms, "send_email")
@@ -131,7 +137,7 @@ def test_send_comms(mocker, tc):
         if isinstance(tc.data, list) or tc.data is None
         else [tc.data],
     )
-    c.Commands().send_comms(["--path", "/asdf/ghsdf", "--confirm", *tc.args])
+    cli("send_comms", ["--path", "/asdf/ghsdf", "--confirm", *tc.args])
     for fn, tcall in [
         (c.comms.send_email, tc.email),
         (c.airtable.log_comms, tc.log),

--- a/protohaven_api/commands/decorator.py
+++ b/protohaven_api/commands/decorator.py
@@ -4,6 +4,8 @@ import functools
 
 import yaml
 
+from protohaven_api.config import get_config
+
 
 def command(*parser_args):
     """Returns a configured decorator that provides help info based on the function comment
@@ -18,7 +20,7 @@ def command(*parser_args):
             for cmd, pkwarg in parser_args:
                 parser.add_argument(cmd, **pkwarg)
             parsed_args = parser.parse_args(args[1])  # argv
-            return func(args[0], parsed_args)
+            return func(args[0], parsed_args, *args[2:])
 
         wrapper.is_command = True
         return wrapper
@@ -52,5 +54,10 @@ def dump_yaml(data):
 
 
 def print_yaml(data):
-    """Prints yaml to stdout"""
-    print(dump_yaml(data))
+    """Prints yaml to config defined path, or to stdout if not set"""
+    path = get_config("general/yaml_out").strip()
+    if path:
+        with open(path, "w", encoding="utf8") as f:
+            f.write(dump_yaml(data))
+    else:
+        print(dump_yaml(data))

--- a/protohaven_api/commands/decorator.py
+++ b/protohaven_api/commands/decorator.py
@@ -1,10 +1,13 @@
 """Basic decorator for argparse commands that wraps functions so they can be executed in cli."""
 import argparse
 import functools
+import logging
 
 import yaml
 
 from protohaven_api.config import get_config
+
+log = logging.getLogger("decorator")
 
 
 def command(*parser_args):
@@ -56,7 +59,8 @@ def dump_yaml(data):
 def print_yaml(data):
     """Prints yaml to config defined path, or to stdout if not set"""
     path = get_config("general/yaml_out").strip()
-    if path:
+    if path and path != "${YAML_OUT}":
+        log.info(f"Writing yaml file to '{path}'")
         with open(path, "w", encoding="utf8") as f:
             f.write(dump_yaml(data))
     else:

--- a/protohaven_api/commands/development.py
+++ b/protohaven_api/commands/development.py
@@ -45,7 +45,7 @@ class Commands:  # pylint: disable=too-few-public-methods
         arg("--path", help="Path to destination file", type=str, required=True),
         arg("--after", help="Earliest date for event data", type=str, required=True),
     )
-    def gen_mock_data(self, args):  # pylint: disable=too-many-locals
+    def gen_mock_data(self, args, _):  # pylint: disable=too-many-locals
         """Fetch mock data from airtable, neon etc.
         Write this to a file for running without touching production data"""
         log.info("Fetching events from neon...")

--- a/protohaven_api/commands/development_test.py
+++ b/protohaven_api/commands/development_test.py
@@ -1,12 +1,19 @@
 """Tests for development CLI commands"""
-
 import pickle
 
+import pytest
+
 from protohaven_api.commands import development as dev
-from protohaven_api.testing import d
+from protohaven_api.testing import d, mkcli
 
 
-def test_gen_mock_data(mocker, tmp_path):
+@pytest.fixture(name="cli")
+def fixture_cli(capsys):
+    """Create CLI fixture"""
+    return mkcli(capsys, dev)
+
+
+def test_gen_mock_data(mocker, tmp_path, cli):
     """Test `gen_mock_data` command"""
     for n in (
         "fetch_events",
@@ -17,8 +24,9 @@ def test_gen_mock_data(mocker, tmp_path):
         mocker.patch.object(dev.neon, n, return_value=[])
     mocker.patch.object(dev.neon_base, "fetch_account", return_value=({"a": 1}, False))
     mocker.patch.object(dev.airtable, "get_all_records", return_value=[])
-    dev.Commands().gen_mock_data(
-        ["--path", str(tmp_path / "test.pkl"), "--after", d(0).isoformat()]
+    cli(
+        "gen_mock_data",
+        ["--path", str(tmp_path / "test.pkl"), "--after", d(0).isoformat()],
     )
     with open(str(tmp_path / "test.pkl"), "rb") as f:
         got = pickle.load(f)

--- a/protohaven_api/commands/docs.py
+++ b/protohaven_api/commands/docs.py
@@ -12,7 +12,7 @@ class Commands:  # pylint: disable=too-few-public-methods
     """Commands for managing roles of members"""
 
     @command()
-    def validate_docs(self, _):
+    def validate_docs(self, _1, _2):
         """Go through list of tools in airtable, ensure all of them have
         links to a tool guide and a clearance doc that resolve successfully"""
         result = validate_docs()

--- a/protohaven_api/commands/finances.py
+++ b/protohaven_api/commands/finances.py
@@ -30,7 +30,7 @@ class Commands:
     """Commands for managing classes in Airtable and Neon"""
 
     @command()
-    def transaction_alerts(self, _):  # pylint: disable=too-many-locals
+    def transaction_alerts(self, _1, _2):  # pylint: disable=too-many-locals
         """Send alerts about recent/unresolved transaction issues"""
         log.info("Fetching customer mapping")
         cust_map = sales.get_customer_name_map()
@@ -192,7 +192,7 @@ class Commands:
             type=str,
         ),
     )
-    def validate_memberships(self, args):
+    def validate_memberships(self, args, _):
         """Loops through all accounts and verifies that memberships are correctly set"""
         if args.member_ids is not None:
             args.member_ids = [m.strip() for m in args.member_ids.split(",")]
@@ -461,7 +461,7 @@ class Commands:
             default="",
         ),
     )
-    def init_new_memberships(self, args):
+    def init_new_memberships(self, args, _):
         """Perform initialization steps for new members: deferring membership until first
         sign-in and creation of a coupon for their first class.
 

--- a/protohaven_api/commands/finances.py
+++ b/protohaven_api/commands/finances.py
@@ -485,16 +485,12 @@ class Commands:
                 log.debug(f"Skipping {aid}: not in filter")
                 continue
 
-            latest = (None, None)
-            for mem in neon.fetch_memberships(aid):
-                tsd = dateparser.parse(mem["termStartDate"]).astimezone(tz)
-                if not latest[1] or latest[1] < tsd:
-                    latest = (mem["id"], tsd)
-            if not latest[0]:
+            membership_id = neon.get_latest_membership_id(aid)
+            if not membership_id:
                 raise RuntimeError(f"No latest membership for member {aid}")
             kwargs = {
                 "account_id": aid,
-                "membership_id": latest[0],
+                "membership_id": membership_id,
                 "email": m["Email 1"],
                 "fname": m["First Name"],
                 "coupon_amount": args.coupon_amount,

--- a/protohaven_api/commands/forwarding.py
+++ b/protohaven_api/commands/forwarding.py
@@ -41,7 +41,7 @@ class Commands:
             default=False,
         ),
     )
-    def project_requests(self, args):
+    def project_requests(self, args, _):
         """Send alerts when new project requests fall into Asana"""
         if not args.apply:
             log.info(
@@ -80,7 +80,7 @@ class Commands:
         print_yaml(results)
 
     @command()
-    def shop_tech_applications(self, _):
+    def shop_tech_applications(self, _1, _2):
         """Send reminders to check shop tech applicants"""
         num = 0
         open_applicants = []
@@ -101,7 +101,7 @@ class Commands:
             )
 
     @command()
-    def instructor_applications(self, _):
+    def instructor_applications(self, _1, _2):
         """Send reminders to check for instructor applications"""
         num = 0
         open_applicants = []
@@ -194,7 +194,7 @@ class Commands:
             default=False,
         ),
     )
-    def private_instruction(self, args):  # pylint: disable=
+    def private_instruction(self, args, _):  # pylint: disable=
         """Generate reminders to take action on private instruction.
         This targets membership@ email and Discord's #instructors/#education-leads channels
         """
@@ -251,7 +251,7 @@ class Commands:
             default=False,
         ),
     )
-    def phone_messages(self, args):
+    def phone_messages(self, args, _):
         """Check on phone messages and forward to email"""
         if not args.apply:
             log.info(
@@ -288,7 +288,7 @@ class Commands:
     @command(
         arg("--now", help="Override current time", type=str, default=None),
     )
-    def tech_sign_ins(self, args):
+    def tech_sign_ins(self, args, _):
         """Craft a notification to indicate whether the scheduled techs have signed in
         for their shift"""
         now = tznow() if not args.now else dateparser.parse(args.now).astimezone(tz)
@@ -342,7 +342,7 @@ class Commands:
         print_yaml(result)
 
     @command()
-    def purchase_request_alerts(self, _):
+    def purchase_request_alerts(self, _1, _2):
         """Send alerts when there's purchase requests that haven't been acted upon for some time"""
         sections = defaultdict(list)
         counts = defaultdict(int)

--- a/protohaven_api/commands/forwarding.py
+++ b/protohaven_api/commands/forwarding.py
@@ -10,11 +10,7 @@ from dateutil import parser as dateparser
 
 from protohaven_api.automation.techs import techs as forecast
 from protohaven_api.commands.decorator import arg, command, print_yaml
-from protohaven_api.config import (  # pylint: disable=import-error
-    exec_details_footer,
-    tz,
-    tznow,
-)
+from protohaven_api.config import tz, tznow  # pylint: disable=import-error
 from protohaven_api.integrations import (  # pylint: disable=import-error
     airtable,
     neon,
@@ -121,7 +117,7 @@ class Commands:
             )
 
     @command()
-    def class_proposals(self, _):
+    def class_proposals(self, _1, _2):
         """Send reminders to take action on proposed classes"""
         num = 0
         unapproved_classes = []
@@ -301,8 +297,9 @@ class Commands:
 
         # Current day from calendar
         techs_on_duty = forecast.generate(now, 1)["calendar_view"][0]
+        log.info(f"Forecast: {techs_on_duty}")
         # Pick AM vs PM shift
-        techs_on_duty = techs_on_duty[0 if shift.endswith("AM") else 1]["people"]
+        techs_on_duty = techs_on_duty["AM" if shift.endswith("AM") else "PM"]["people"]
         log.info(f"Expecting on-duty techs: {techs_on_duty}")
         email_map = {
             t["email"]: t["name"]
@@ -335,7 +332,6 @@ class Commands:
                         (v, rev_email_map.get(v, "unknown email"))
                         for v in techs_on_duty
                     ],
-                    footer=exec_details_footer(),
                 )
             )
 

--- a/protohaven_api/commands/forwarding_test.py
+++ b/protohaven_api/commands/forwarding_test.py
@@ -49,7 +49,10 @@ def test_tech_sign_ins(mocker, tc, cli):
         "generate",
         return_value={
             "calendar_view": [
-                [{"people": [AM_TECH["name"]]}, {"people": [PM_TECH["name"]]}]
+                {
+                    "AM": {"people": [AM_TECH["name"]]},
+                    "PM": {"people": [PM_TECH["name"]]},
+                }
             ]
         },
     )

--- a/protohaven_api/commands/maintenance.py
+++ b/protohaven_api/commands/maintenance.py
@@ -66,7 +66,7 @@ class Commands:
             default=True,
         ),
     )
-    def gen_maintenance_tasks(self, args):
+    def gen_maintenance_tasks(self, args, _):
         """Check recurring tasks list in Airtable, add new tasks to asana
         And notify techs about new and stale tasks that are tech_ready."""
         tt = manager.run_daily_maintenance(args.apply)
@@ -83,7 +83,7 @@ class Commands:
         )
 
     @command()
-    def gen_tech_leads_maintenance_summary(self, _):
+    def gen_tech_leads_maintenance_summary(self, _1, _2):
         """Report on status of equipment maintenance & stale tasks"""
         stale = manager.get_stale_tech_ready_tasks()
         if len(stale) > 0:

--- a/protohaven_api/commands/reservations.py
+++ b/protohaven_api/commands/reservations.py
@@ -3,12 +3,14 @@
 import argparse
 import datetime
 import logging
+from functools import lru_cache
 
 from dateutil import parser as dateparser
 
 from protohaven_api.commands.decorator import arg, command, print_yaml
 from protohaven_api.config import (  # pylint: disable=import-error
     exec_details_footer,
+    get_config,
     tz,
 )
 from protohaven_api.integrations import airtable, booked  # pylint: disable=import-error
@@ -162,22 +164,68 @@ class Commands:
                             )
                         )
 
-    def _stage_booked_record_update(self, r, custom_attributes, **kwargs):
-        changes = []
-        r, changed_attrs = booked.stage_custom_attributes(r, **custom_attributes)
-        if True in changed_attrs.values():
-            changes.append(
-                f"custom attributes ({changed_attrs} -> {custom_attributes})"
+    @lru_cache(maxsize=1)
+    def _area_colors(self):
+        ac = {}
+        for a in airtable.get_areas():
+            if not a["fields"].get("Name"):
+                continue
+            ac[a["fields"]["Name"]] = a["fields"].get("Color")
+        return ac
+
+    def _sync_reservable_tool(self, r, t):
+        name = t["fields"].get("Tool Name")
+        area = t["fields"].get("Name (from Shop Area)", [None])[0]
+        if not area:
+            raise RuntimeError(
+                f"Airtable tool record {t['id']} missing name and/or area: {name} {area}"
             )
-            log.warning(
-                f"Changed custom attributes: {changed_attrs} -> {custom_attributes}"
+
+        resource_id = t["fields"].get("BookedResourceId")
+        clearance_code = (
+            t["fields"].get("Clearance Code (from Clearance Required)", [None])[0] or ""
+        )
+        tool_code = t["fields"].get("Tool Code")
+
+        log.info(f'{tool_code} #{resource_id} "{name}"')
+        r = booked.get_resource(resource_id)
+        return booked.stage_tool_update(
+            r,
+            {
+                "area": area,
+                "tool_code": tool_code,
+                "clearance_code": clearance_code,
+            },
+            reservable=True,
+            name=f"{area} - {name}",
+            color=self._area_colors().get(area) or "",
+            # 3D printers allow reservations across days
+            allowMultiday=(area == "3D Printing"),
+        )
+
+    def _sync_booked_permissions(
+        self, airtable_booked_ids, all_resources, summary, apply
+    ):
+        perms = set(booked.get_members_group_tool_permissions())
+        perms_delta = airtable_booked_ids - perms
+        if len(perms_delta) > 0:
+            log.info(
+                "The following tool IDs aren't part of the Members group in Booked:"
             )
-        for k, v in kwargs.items():
-            if str(r[k]) != str(v):
-                log.warning(f"Changing {k} from {r[k]} to {v}")
-                r[k] = v
-                changes.append(f"{k} ({r[k]}->{v})")
-        return r, changes
+            for missing in [
+                f"#{v['resourceId']} {v['name']}"
+                for r, v in all_resources.items()
+                if r in perms_delta
+            ]:
+                log.info(missing)
+                summary.append(f"Add to Members group: {missing}")
+            if apply:
+                log.info("Updating Members group tool permissions...")
+                # Note that `airtable_booked_ids` is populated such that all entries
+                # are known to exist in Booked.
+                log.info(
+                    str(booked.set_members_group_tool_permissions(airtable_booked_ids))
+                )
 
     @command(
         arg(
@@ -185,7 +233,12 @@ class Commands:
             help="If false, don't perform changes",
             action=argparse.BooleanOptionalAction,
             default=False,
-        )
+        ),
+        arg(
+            "--filter",
+            help="CSV of Airtable tool codes to constrain sync to",
+            default=None,
+        ),
     )
     def sync_reservable_tools(
         self, args
@@ -204,35 +257,17 @@ class Commands:
         """
         if not args.apply:
             log.warning("==== --apply NOT SET, NO CHANGES WILL BE MADE ====")
+        if args.filter is not None:
+            args.filter = {a.strip() for a in args.filter.split(",")}
+            log.warning(f"Filtering to tools by tool code: {args.filter}")
 
-        # Some areas we don't care about in the reservation system; these are excluded
-        exclude_areas = {
-            "Class Supplies",
-            "Maintenance",
-            "Staff Room",
-            "Back Yard",
-            "Fishbowl",
-            "Maker Market",
-            "Rack Storage",
-            "Restroom 1",
-            "Restroom 2",
-            "Kitchen",
-            "Gallery",
-            "Custodial Room",
-            "All",
-        }
-
-        area_colors = {}
-        for a in airtable.get_areas():
-            if not a["fields"].get("Name"):
-                continue
-            area_colors[a["fields"]["Name"]] = a["fields"].get("Color")
-
+        exclude_areas = set(get_config("booked/exclude_areas"))
+        log.info(f"Will exclude syncing areas: {exclude_areas}")
         groups = {
             k.replace("&amp;", "&"): v
             for k, v in booked.get_resource_group_map().items()
         }
-        in_airtable = set(area_colors.keys()) - exclude_areas
+        in_airtable = set(self._area_colors().keys()) - exclude_areas
         in_booked = set(groups.keys()) - exclude_areas
 
         log.info(
@@ -250,76 +285,39 @@ class Commands:
                 "https://reserve.protohaven.org/Web/admin/resources/#/groups"
             )
 
-        # print("Resource Group ID map:")
-        # for k,v in groups.items():
-        #    print(f"- {k} = {v}")
         airtable_booked_ids = set()
         summary = []
+        all_resources = {r["resourceId"]: r for r in booked.get_resources()}
         for t in airtable.get_tools():
             if not t["fields"].get("Reservable", False):
                 continue
-            d = {
-                "name": t["fields"].get("Tool Name"),
-                "resourceId": t["fields"].get("BookedResourceId"),
-                "reservable": t["fields"]
-                .get("Current Status", "Unknown")
-                .split()[0]
-                .lower()
-                in ("green", "yellow"),
-                "area": t["fields"].get("Name (from Shop Area)", [None])[0],
-                "clearance_code": t["fields"].get(
-                    "Clearance Code (from Clearance Required)", [None]
-                )[0]
-                or "",
-                "tool_code": t["fields"].get("Tool Code"),
-            }
-            if not d["name"] or not d["area"]:
-                log.warning(f"Record {t['id']} missing name or area: {d}")
+            r = all_resources.get(t["fields"].get("BookedResourceId"))
+            if not r:
+                summary.append(f"Create placeholder resource for {t['fields']['Name']}")
+                log.info(summary[-1])
+                if args.apply:
+                    r = booked.create_resource("placeholder")
+                    airtable.set_booked_resource_id(t["id"], r["resourceId"])
 
-            if not d[
-                "resourceId"
-            ]:  # New tool! Create the record. We'll update it in a second step
-                log.warning(f"Creating new resource {d['name']}")
-                summary.append(f"Create new Booked resource {d['name']}")
-                if not args.apply:
-                    log.warning(f"Skipping creation of new resource {d['name']}")
-                    continue
-                rep = booked.create_resource(d["name"])
-                log.debug(str(rep))
-                log.debug("Updating airtable record")
-                d["resourceId"] = rep["resourceId"]
-                rep = airtable.set_booked_resource_id(t["id"], d["resourceId"])
-                log.debug(str(rep))
-            airtable_booked_ids.add(d["resourceId"])
+            if not r:  # Note: args.apply == False or insert failure results in r = None
+                continue
 
-            log.info(f"#{d['resourceId']} \"{d['name']}\"")
-            r = booked.get_resource(d["resourceId"])
-            r, changes = self._stage_booked_record_update(
-                r,
-                {
-                    "area": d["area"],
-                    "tool_code": d["tool_code"],
-                    "clearance_code": d["clearance_code"],
-                },
-                name=f"{d['area']} - {d['name']}",
-                statusId=(
-                    booked.STATUS_AVAILABLE
-                    if d["reservable"]
-                    else booked.STATUS_UNAVAILABLE
-                ),
-                typeId=booked.TYPE_TOOL,
-                color=area_colors.get(d.get("area")) or "",
-                allowMultiday=d.get("area")
-                == "3D Printing",  # 3D printers allow reservations across days
-            )
+            airtable_booked_ids.add(int(r["resourceId"]))
+            if (
+                args.filter is not None
+                and t["fields"].get("Tool Code").strip().upper() not in args.filter
+            ):
+                continue
+
+            r, changes = self._sync_reservable_tool(r, t)
             if changes:
-                summary.append(f"Change {d['name']}: {', '.join(changes)}")
+                summary.append(f"Change {r['name']}: {', '.join(changes)}")
                 if args.apply:
                     log.info(booked.update_resource(r))
 
-        # Note 2024-04-15: groupIds don't seem to be editable via standard
-        # update. We'd have to mock admin panel behavior
-        # groupIds=[groups[a] for a in d.get("area", []) if a is not None],
+        self._sync_booked_permissions(
+            airtable_booked_ids, all_resources, summary, args.apply
+        )
 
         extra_booked_resources = {
             k: v

--- a/protohaven_api/commands/roles.py
+++ b/protohaven_api/commands/roles.py
@@ -53,7 +53,7 @@ class Commands:  # pylint: disable=too-few-public-methods
             default=False,
         ),
     )
-    def update_role_intents(self, args):  # pylint: disable=too-many-locals
+    def update_role_intents(self, args, _):  # pylint: disable=too-many-locals
         """Syncs the roles in discord with the state of membership and custom fields in Neon.
         Role revocations are delayed and users DM'd in advance of the change, so they
         have time to remedy the cause of the revocation.
@@ -154,7 +154,7 @@ class Commands:  # pylint: disable=too-few-public-methods
         ),
     )
     def enforce_discord_nicknames(
-        self, args
+        self, args, _
     ):  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         """Ensure nicknames of all associated Discord users are properly set.
         This only targets active members, as inactive members shouldn't

--- a/protohaven_api/commands/roles.py
+++ b/protohaven_api/commands/roles.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 from protohaven_api.automation.roles import roles
 from protohaven_api.commands.decorator import arg, command, print_yaml
-from protohaven_api.config import exec_details_footer, tznow
+from protohaven_api.config import tznow
 from protohaven_api.integrations import airtable, comms, neon
 from protohaven_api.integrations.comms import Msg
 
@@ -281,7 +281,6 @@ class Commands:  # pylint: disable=too-few-public-methods
                     n=len(changes),
                     notified=notified,
                     m=m,
-                    footer=exec_details_footer(),
                 )
             )
 

--- a/protohaven_api/commands/violations.py
+++ b/protohaven_api/commands/violations.py
@@ -20,7 +20,7 @@ class Commands:  # pylint: disable=too-few-public-methods
             default=False,
         )
     )
-    def enforce_policies(self, args):
+    def enforce_policies(self, args, _):
         """Follows violation logic for any ongoing violations.
         For any violation tagged with a user, generate comms.
         For any action needed to suspend users, generate comms.

--- a/protohaven_api/commands/violations_test.py
+++ b/protohaven_api/commands/violations_test.py
@@ -1,14 +1,22 @@
-# pylint: skip-file
+"""Test violations commands"""
+
+import pytest
+
 from protohaven_api.automation.policy import enforcer as e
 from protohaven_api.commands import violations as v
+from protohaven_api.testing import mkcli
 
 
-def test_enforce_policies_no_output(mocker, capsys):
+@pytest.fixture(name="cli")
+def fixture_cli(capsys):
+    """Create CLI fixture"""
+    return mkcli(capsys, v)
+
+
+def test_enforce_policies_no_output(mocker, cli):
     """Confirm that when there are no violations, we send no notifications"""
     mocker.patch.object(v.airtable, "get_policy_violations", return_value=[])
     mocker.patch.object(v.airtable, "get_policy_fees", return_value=[])
     mocker.patch.object(e.airtable, "get_policy_sections", return_value=[])
     mocker.patch.object(v.enforcer, "gen_fees", return_value=[])
-    v.Commands().enforce_policies(["--apply"])
-    captured = capsys.readouterr()
-    assert captured.out.strip() == "[]"
+    assert cli("enforce_policies", ["--apply"]) == []

--- a/protohaven_api/config.py
+++ b/protohaven_api/config.py
@@ -20,10 +20,6 @@ ENV_SECRETS_PATH = ".env.secret"
 CONFIG_YAML_PATH = "config.yaml"
 CONFIG_YAML_ENV = "PH_CONFIG"
 
-# Part of Cronicle job environment variables
-# https://github.com/jhuckaby/Cronicle/blob/6cf86b783f15f4d0754c7fb6e58cad0332fd79f9/docs/Plugins.md#job-environment-variables
-JOB_ID_ENV = "JOB_ID"
-
 
 def utcnow():
     """Returns current time in UTC"""
@@ -89,27 +85,3 @@ def mock_data():
     """Fetches mock data from .pkl file"""
     with open(MOCK_DATA_PATH, "rb") as f:
         return pickle.load(f)
-
-
-@lru_cache(maxsize=1)
-def get_execution_log_link():
-    """If this process is executed asynchronously via Cronicle, return a link
-    to the execution log of the job. If we're not running as part of a Cronicle job,
-    return None.
-
-    Cronicle injects environment variables upon execution of a job, including `JOB_ID`.
-    This was confirmed via a call to `printenv` inside of a Cronicle job.
-    """
-    job_id = os.getenv(JOB_ID_ENV, None)
-    base = get_config("cronicle/base_url")
-    if job_id:
-        return f"{base}/#JobDetails?id={job_id}"
-    return None
-
-
-def exec_details_footer():
-    """Return a formatted footer with details related to cron-style execution of this
-    process.
-    """
-    l = get_execution_log_link()
-    return "" if not l else f"\n*See [execution log]({l})*"

--- a/protohaven_api/config_test.py
+++ b/protohaven_api/config_test.py
@@ -4,16 +4,6 @@ import pytest
 from protohaven_api import config as c
 
 
-def test_exec_details_footer(mocker):
-    mocker.patch.object(c, "get_execution_log_link", return_value="TEST_LINK")
-    assert "TEST_LINK" in c.exec_details_footer()
-
-
-def test_exec_details_footer_empty(mocker):
-    mocker.patch.object(c, "get_execution_log_link", return_value=None)
-    assert c.exec_details_footer() == ""
-
-
 @pytest.mark.parametrize(
     "data,path,default,want",
     [

--- a/protohaven_api/handlers/admin.py
+++ b/protohaven_api/handlers/admin.py
@@ -107,12 +107,15 @@ def neon_membership_created_callback():
         "neon/webhooks/new_membership/enabled", default=False, as_bool=True
     )
     if not is_enabled:
+        log.info("Skipping new membership callback - not initialized")
         return Response("Membership initializer disabled via config", status=200)
     api_key = request.json.get("customParameters", {}).get("api_key")
+    log.info("New membership callback received")
     log.info(f"api key is {api_key}")
     roles = roles_from_api_key(api_key) or []
     log.info(f"roles are {roles}")
     if Role.AUTOMATION["name"] not in roles:
+        log.warning("Membership callback not authorized; ignoring")
         return Response("Not authorized", status=400)
 
     data = request.json["data"]["membership"]

--- a/protohaven_api/handlers/admin_test.py
+++ b/protohaven_api/handlers/admin_test.py
@@ -15,7 +15,7 @@ def fixture_client():
 
 NEW_MEMBERSHIP_WEBHOOK_DATA = {
     "data": {
-        "membership": {
+        "membershipEnrollment": {
             "membershipId": 134,
             "accountId": 123958,
             "membershipTerm": {
@@ -32,8 +32,10 @@ NEW_MEMBERSHIP_WEBHOOK_DATA = {
             "termEndDate": "2024-08-31-05:00",
             "enrollmentType": "JOIN",
             "status": "Succeed",
-            "transaction": {},
-        }
+        },
+        "transaction": {
+            "transactionStatus": "SUCCESS",
+        },
     },
     "customParameters": {
         "api_key": "TEST KEY",  # pragma: allowlist secret
@@ -44,7 +46,7 @@ NEW_MEMBERSHIP_WEBHOOK_DATA = {
 @pytest.mark.parametrize(
     "field_value,does_init",
     [
-        (None, True),
+        (None, True),  # If not initialized, do so
         ("asdf", False),  # Bail if setup is already done
     ],
 )

--- a/protohaven_api/integrations/booked.py
+++ b/protohaven_api/integrations/booked.py
@@ -163,10 +163,8 @@ def stage_tool_update(r, custom_attributes, reservable=True, **kwargs):
         )
     for k, v in kwargs.items():
         if str(r[k]) != str(v):
-            log.warning(
-                f"Changing {k} from {_fmt_update(k,r[k])} to {_fmt_update(k,v)}"
-            )
-            changes.append(f"{k} ({r[k]}->{v})")
+            changes.append(f"{k} ({_fmt_update(k,r[k])}->{_fmt_update(k,v)})")
+            log.warning(changes[-1])
             r[k] = v
     return r, changes
 

--- a/protohaven_api/integrations/booked_test.py
+++ b/protohaven_api/integrations/booked_test.py
@@ -8,11 +8,12 @@ from protohaven_api.integrations import booked
 def test_get_resource_map(mocker):
     """Basic test of `get_resource_map`, that it calls out and returns mapped values"""
     mocker.patch.object(booked, "get_connector")
-    booked.get_connector().booked_request().json.return_value = {
+    booked.get_connector().booked_request.return_value = {
         "resources": [
             {"customAttributes": [{"id": 3, "value": "ABC"}], "resourceId": 123}
         ]
     }
+    mocker.patch.object(booked, "get_config", return_value=3)
     assert booked.get_resource_map() == {"ABC": 123}
 
 
@@ -21,7 +22,7 @@ def test_get_resource_singleton(mocker):
     mocker.patch.object(booked, "get_connector")
     booked.get_resource("test_id")
     booked.get_connector().booked_request.assert_called_once_with(  # pylint: disable=no-member
-        "GET", "https://reserve.protohaven.org/Web/Services/Resources/test_id"
+        "GET", "/Resources/test_id"
     )
 
 
@@ -31,7 +32,7 @@ def test_get_reservations(mocker):
     booked.get_reservations(parse_date("2024-01-01"), parse_date("2024-02-02"))
     booked.get_connector().booked_request.assert_called_once_with(  # pylint: disable=no-member
         "GET",
-        "https://reserve.protohaven.org/Web/Services/Reservations/?startDateTime=2024-01-01T00:00:00&endDateTime=2024-02-02T00:00:00",  # pylint: disable=line-too-long
+        "/Reservations/?startDateTime=2024-01-01T00:00:00&endDateTime=2024-02-02T00:00:00",  # pylint: disable=line-too-long
     )
 
 
@@ -41,7 +42,7 @@ def test_reserve_resource(mocker):
     booked.reserve_resource(123, parse_date("2024-01-01"), parse_date("2024-01-02"))
     booked.get_connector().booked_request.assert_called_once_with(  # pylint: disable=no-member
         "POST",
-        "https://reserve.protohaven.org/Web/Services/Reservations/",
+        "/Reservations/",
         json={
             "description": "api.protohaven.org reservation",
             "endDateTime": "2024-01-02T00:00:00",
@@ -64,7 +65,7 @@ def test_apply_resource_custom_fields(mocker):
     booked.apply_resource_custom_fields(123, area="Foo")
     booked.get_connector().booked_request.assert_called_once_with(  # pylint: disable=no-member
         "POST",
-        "https://reserve.protohaven.org/Web/Services/Resources/123",
+        "/Resources/123",
         json={
             "customAttributes": [
                 {"attributeId": 3, "attributeValue": "ABC"},

--- a/protohaven_api/integrations/comms.py
+++ b/protohaven_api/integrations/comms.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from protohaven_api.config import get_config
+from protohaven_api.integrations.cronicle import exec_details_footer
 from protohaven_api.integrations.data.connector import get as get_connector
 
 
@@ -72,6 +73,8 @@ class Msg:
     @classmethod
     def tmpl(cls, tmpl, **kwargs):
         """Construct a `Msg` object via a template."""
+        if "footer" not in kwargs:
+            kwargs["footer"] = exec_details_footer()
         subject, body, is_html = render(tmpl, **kwargs)
         self_args = {k: v for k, v in kwargs.items() if k in cls.EXTRA_FIELDS}
         return cls(**self_args, subject=subject, body=body, html=is_html)

--- a/protohaven_api/integrations/comms_test.py
+++ b/protohaven_api/integrations/comms_test.py
@@ -79,6 +79,7 @@ TESTED_TEMPLATES = [
             }
         },
     ),
+    ("booked_member_sync_summary", {"n": 5, "changes": [1, 2, 3]}),
     ("class_proposals", {"unapproved": ["Unap1", "Unap2"]}),
     (
         "class_scheduled",
@@ -152,7 +153,13 @@ TESTED_TEMPLATES = [
     ),
     (
         "instructors_new_classes",
-        {"formatted": ["a", "b", "c"], "n": 3},
+        {
+            "classes": [
+                {"start": "YYYY-MM-DD", "name": "Test Class", "inst": "Instructor"},
+                {"start": "YYYY-MM-DD", "name": "Test class without instructor info"},
+            ],
+            "n": 3,
+        },
     ),
     (
         "membership_activated",
@@ -308,6 +315,7 @@ TESTED_TEMPLATES = [
 HASHES = {
     "test_template": "b8a27190aa3ed922",  # pragma: allowlist secret
     "test_html_template": "77606b5538c73e78",  # pragma: allowlist secret
+    "booked_member_sync_summary": "9a2589742196885e",  # pragma: allowlist secret
     "class_automation_summary": "866427c2de1c186f",  # pragma: allowlist secret
     "class_proposals": "09aa7102c43e69e6",  # pragma: allowlist secret
     "class_scheduled": "d7638c67655ae1eb",  # pragma: allowlist secret
@@ -326,7 +334,7 @@ HASHES = {
     "instructor_log_reminder": "d00bf87676ad240e",  # pragma: allowlist secret
     "instructor_low_attendance": "e7b4548a7a3f7fc2",  # pragma: allowlist secret
     "instructor_schedule_classes": "39aea10c71fc8895",  # pragma: allowlist secret
-    "instructors_new_classes": "c3cbf1129a256abe",  # pragma: allowlist secret
+    "instructors_new_classes": "43f58a36632acefb",  # pragma: allowlist secret
     "membership_activated": "8a27b2ff8900b48b",  # pragma: allowlist secret
     "membership_init_summary": "40ebdf94a4ada4af",  # pragma: allowlist secret
     "membership_validation_problems": "e9b4740d33220373",  # pragma: allowlist secret
@@ -345,7 +353,7 @@ HASHES = {
     "tech_leads_maintenance_status": "e763f572fa0203a5",  # pragma: allowlist secret
     "tech_openings": "f9bd7999e37d1ebd",  # pragma: allowlist secret
     "tool_documentation": "30faa1dfb4e04a20",  # pragma: allowlist secret
-    "tool_sync_summary": "762670ac5feeddf3",  # pragma: allowlist secret
+    "tool_sync_summary": "82ba40ec440803d4",  # pragma: allowlist secret
     "violation_ongoing": "1ff24f039d2d424a",  # pragma: allowlist secret
     "violation_started": "12527581a8fbdd2d",  # pragma: allowlist secret
 }

--- a/protohaven_api/integrations/cronicle.py
+++ b/protohaven_api/integrations/cronicle.py
@@ -1,0 +1,53 @@
+"""Convenience methods for acting as a Cronicle job"""
+
+from functools import lru_cache
+from os import getenv
+
+from protohaven_api.config import get_config
+
+# Part of Cronicle job environment variables
+# https://github.com/jhuckaby/Cronicle/blob/6cf86b783f15f4d0754c7fb6e58cad0332fd79f9/docs/Plugins.md#job-environment-variables
+JOB_ID_ENV = "JOB_ID"
+
+
+@lru_cache(maxsize=1)
+def get_execution_log_link():
+    """If this process is executed asynchronously via Cronicle, return a link
+    to the execution log of the job. If we're not running as part of a Cronicle job,
+    return None.
+
+    Cronicle injects environment variables upon execution of a job, including `JOB_ID`.
+    This was confirmed via a call to `printenv` inside of a Cronicle job.
+    """
+    job_id = getenv(JOB_ID_ENV, None)
+    base = get_config("cronicle/base_url")
+    if job_id:
+        return f"{base}/#JobDetails?id={job_id}"
+    return None
+
+
+def exec_details_footer():
+    """Return a formatted footer with details related to cron-style execution of this
+    process.
+    """
+    l = get_execution_log_link()
+    return "" if not l else f"\n*See [execution log]({l})*"
+
+
+class Progress:
+    """A simple progress reporter that allows for multiple stages/loops"""
+
+    def __init__(self, n=1, on=None):
+        self.on = on or (get_execution_log_link() is not None)
+        self.n = n
+
+    def set_stages(self, n):
+        """Set the number of stages of progress"""
+        self.n = n
+
+    def __setitem__(self, i, v):
+        """Writes progress to stdout for reading by Cronicle.
+        This is omitted if we're not running as a cronicle job."""
+        pct = f"{(v + i) / self.n:.2f}"
+        if self.on:
+            print('{ "progress": ' + pct + " }")

--- a/protohaven_api/integrations/cronicle_test.py
+++ b/protohaven_api/integrations/cronicle_test.py
@@ -1,0 +1,15 @@
+"""Test cronicle integration"""
+
+from protohaven_api.integrations import cronicle as c
+
+
+def test_exec_details_footer(mocker):
+    """Test that exec details footer is sucessfully linked"""
+    mocker.patch.object(c, "get_execution_log_link", return_value="TEST_LINK")
+    assert "TEST_LINK" in c.exec_details_footer()
+
+
+def test_exec_details_footer_empty(mocker):
+    """Test that the footer is empty when not run in a Cronicle job context"""
+    mocker.patch.object(c, "get_execution_log_link", return_value=None)
+    assert c.exec_details_footer() == ""

--- a/protohaven_api/integrations/data/connector.py
+++ b/protohaven_api/integrations/data/connector.py
@@ -6,6 +6,7 @@ import random
 import time
 from email.mime.text import MIMEText
 from threading import Lock
+from urllib.parse import urljoin
 
 import asana
 import requests
@@ -156,15 +157,26 @@ class Connector:
         """Executes a function synchronously on the discord bot"""
         return getattr(discord_bot.get_client(), fn)(*args, **kwargs)
 
-    def booked_request(self, *args, **kwargs):
+    def booked_request(self, mode, api_suffix, *args, **kwargs):
         """Make a request to the Booked reservation system"""
+        url = urljoin(get_config("booked/base_url"), api_suffix.lstrip("/"))
         headers = {
             "X-Booked-ApiId": get_config("booked/id"),
             "X-Booked-ApiKey": get_config("booked/key"),
         }
-        return requests.request(
-            *args, headers=headers, timeout=DEFAULT_TIMEOUT, **kwargs
+        r = requests.request(
+            mode, url, *args, headers=headers, timeout=DEFAULT_TIMEOUT, **kwargs
         )
+        log.info(f"Response {r}, code {r.status_code}")
+        if r.status_code != 200:
+            raise RuntimeError(
+                f"booked_request(mode={mode}, url={url}, args={args}, "
+                + f"kwargs={kwargs}) returned {r.status_code}: {r.content}"
+            )
+        try:
+            return r.json()
+        except requests.exceptions.JSONDecodeError:
+            return r.content
 
     def square_client(self):
         """Create and return Square API client"""

--- a/protohaven_api/integrations/data/connector.py
+++ b/protohaven_api/integrations/data/connector.py
@@ -167,7 +167,6 @@ class Connector:
         r = requests.request(
             mode, url, *args, headers=headers, timeout=DEFAULT_TIMEOUT, **kwargs
         )
-        log.info(f"Response {r}, code {r.status_code}")
         if r.status_code != 200:
             raise RuntimeError(
                 f"booked_request(mode={mode}, url={url}, args={args}, "

--- a/protohaven_api/integrations/data/neon.py
+++ b/protohaven_api/integrations/data/neon.py
@@ -28,6 +28,7 @@ class CustomField:
     PRONOUNS = 161
     NOTIFY_BOARD_AND_STAFF = 162
     ACCOUNT_AUTOMATION_RAN = 163
+    BOOKED_USER_ID = 165
 
     @classmethod
     def from_id(cls, v):

--- a/protohaven_api/integrations/data/neon.py
+++ b/protohaven_api/integrations/data/neon.py
@@ -1,9 +1,6 @@
 """Constants and other datatypes for Neon integration"""
 from dataclasses import dataclass
 
-URL_BASE = "https://api.neoncrm.com/v2"
-ADMIN_URL = "https://protohaven.app.neoncrm.com/np/admin"
-
 
 class CustomFieldNotFoundError(RuntimeError):
     """Raised when the custom field is not found by an ID"""

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -183,6 +183,17 @@ def create_zero_cost_membership(account_id, start, end, level=None, term=None):
     )
 
 
+def get_latest_membership_id(account_id):
+    """Returns the ID of the membership with the latest start date, or None
+    if there are no memberships for the account under `account_id`."""
+    latest = (None, None)
+    for mem in fetch_memberships(account_id):
+        tsd = dateparser.parse(mem["termStartDate"]).astimezone(tz)
+        if not latest[1] or latest[1] < tsd:
+            latest = (mem["id"], tsd)
+    return latest[0]
+
+
 def set_membership_date_range(membership_id, start, end):
     """Sets the termStartDate of the membership with id `membership_id`."""
     return neon_base.patch(

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -218,6 +218,13 @@ def set_discord_user(account_id, discord_user: str):
     )
 
 
+def set_booked_user_id(account_id, booked_id: str):
+    """Sets the Booked Scheduler ID for this user"""
+    return neon_base.set_custom_fields(
+        account_id, (CustomField.BOOKED_USER_ID, booked_id)
+    )
+
+
 def set_clearances(account_id, code_ids, is_company=None):
     """Sets all clearances for a specific user - company or individual"""
     return neon_base.set_custom_fields(

--- a/protohaven_api/integrations/templates/booked_member_sync_summary.jinja2
+++ b/protohaven_api/integrations/templates/booked_member_sync_summary.jinja2
@@ -1,0 +1,3 @@
+{% if subject %}Booked Member Sync Summary{% else %}Made {{n}} user change(s) in [Booked Scheduler](https://reserve.protohaven.org):
+{% for c in changes %}* {{c}}
+{% endfor %}{{footer}}{% endif %}

--- a/protohaven_api/integrations/templates/instructors_new_classes.jinja2
+++ b/protohaven_api/integrations/templates/instructors_new_classes.jinja2
@@ -1,3 +1,3 @@
 {% if subject %}Scheduled {{n}} new class{% if n != 1 %}es{% endif %}{% else %}
-{% for f in formatted %}{{f}}
+{% for c in classes %}- {{c.start}}: {{c.name}}{% if c.inst %} ({{c.inst}}){% endif %}
 {% endfor %}{% endif %}

--- a/protohaven_api/integrations/templates/tool_sync_summary.jinja2
+++ b/protohaven_api/integrations/templates/tool_sync_summary.jinja2
@@ -1,3 +1,3 @@
 {% if subject %}Tool Sync Summary{% else %}Made {{n}} change(s) in [Booked Scheduler](https://reserve.protohaven.org):
-{% for c in changes %}- {{c}}
+{% for c in changes %}* {{c}}
 {% endfor %}{{footer}}{% endif %}

--- a/protohaven_api/rbac.py
+++ b/protohaven_api/rbac.py
@@ -84,8 +84,8 @@ def roles_from_api_key(api_key):
     codes = get_config("general/external_access_codes")
     try:
         api_key = base64.b64decode(api_key).decode("utf8")
-    except (B64Error, UnicodeDecodeError):
-        pass
+    except (B64Error, UnicodeDecodeError) as e:
+        log.warning(str(e))
     return codes.get(api_key)
 
 

--- a/protohaven_api/rbac.py
+++ b/protohaven_api/rbac.py
@@ -83,9 +83,9 @@ def roles_from_api_key(api_key):
         return None
     codes = get_config("general/external_access_codes")
     try:
-        api_key = base64.b64decode(api_key).decode("utf8")
-    except (B64Error, UnicodeDecodeError) as e:
-        log.warning(str(e))
+        api_key = base64.b64decode(api_key).decode("utf8").strip()
+    except (B64Error, UnicodeDecodeError):
+        pass
     return codes.get(api_key)
 
 

--- a/protohaven_api/testing.py
+++ b/protohaven_api/testing.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 
 from protohaven_api.config import tz
+from protohaven_api.integrations.cronicle import Progress
 from protohaven_api.main import app
 
 
@@ -51,7 +52,7 @@ def mkcli(capsys, module):
     """Invoke CLI, read stdout, and return yaml-ized result text."""
 
     def run(cmd: str, args: list, parse_yaml=True):
-        getattr(module.Commands(), cmd)(args)
+        getattr(module.Commands(), cmd)(args, Progress())
         captured = capsys.readouterr()
         return yaml.safe_load(captured.out) if parse_yaml else captured.out.strip()
 

--- a/svelte/src/lib/techs/area_leads.svelte
+++ b/svelte/src/lib/techs/area_leads.svelte
@@ -4,13 +4,20 @@ import {onMount} from 'svelte';
 import { Table, Button, Row, Col, Card, CardHeader, Badge, CardTitle, Modal, CardSubtitle, CardText, Icon, Tooltip, CardFooter, CardBody, Input, Spinner, FormGroup, Navbar, NavbarBrand, Nav, NavItem, Toast, ToastBody, ToastHeader } from '@sveltestrap/sveltestrap';
 import {get} from '$lib/api.ts';
 
+export let visible;
+let loaded = false;
 let promise = new Promise((resolve) => {});
 function refresh() {
-  promise = get("/techs/area_leads")
+  promise = get("/techs/area_leads").then((data) => {loaded = true; return data;});
 }
-onMount(refresh);
+$: {
+  if (visible && !loaded) {
+    refresh();
+  }
+}
 </script>
 
+{#if visible}
 <Card>
 <CardHeader>
   <CardTitle>Areas &amp; Leads</CardTitle>
@@ -35,3 +42,4 @@ onMount(refresh);
 {/await}
 </CardBody>
 </Card>
+{/if}

--- a/svelte/src/lib/techs/assignments.svelte
+++ b/svelte/src/lib/techs/assignments.svelte
@@ -6,13 +6,20 @@ import { Table, Accordion, AccordionItem, Button, Row, Container, Col, Card, Car
 import FetchError from '../fetch_error.svelte';
 import {get, post} from '$lib/api.ts';
 
+export let visible;
+let loaded = false;
 let promise = new Promise((resolve) => {});
 function refresh() {
-  promise = get("/techs/shifts");
+  promise = get("/techs/shifts").then((data) => {loaded = true; return data;});
 }
-onMount(refresh);
+$: {
+  if (visible && !loaded) {
+    refresh();
+  }
+}
 </script>
 
+{#if visible}
 <Card>
   <CardHeader>
     <CardTitle>Shifts Assigned</CardTitle>
@@ -48,3 +55,4 @@ onMount(refresh);
 {/await}
 </CardBody>
 </Card>
+{/if}

--- a/svelte/src/lib/techs/calendar.svelte
+++ b/svelte/src/lib/techs/calendar.svelte
@@ -1,0 +1,43 @@
+<script type="typescript">
+import { onMount } from 'svelte';
+import {get, put, del, isodate, localtime, as_datetimelocal} from '$lib/api.ts';
+import { Spinner, Table, Badge, Accordion, AccordionItem, FormGroup, InputGroup, InputGroupText, Label, Button, Modal, ModalHeader, ModalBody, ModalFooter, Popover, Input } from '@sveltestrap/sveltestrap';
+import FetchError from '../fetch_error.svelte';
+
+export let weeks; // a list of lists of {date, filler, body}
+export let start_edit_fn;
+</script>
+
+<style>
+  td {
+    cursor: pointer;
+  }
+  td.filler {
+    color: #ddd;
+  }
+</style>
+
+<Table bordered>
+  <thead>
+<tr>
+<th>Su</th>
+<th>Mo</th>
+<th>Tu</th>
+<th>We</th>
+<th>Th</th>
+<th>Fr</th>
+<th>Sa</th>
+</tr>
+</thead>
+<tbody>
+  {#each weeks as w}
+  <tr>
+    {#each w as d}
+    <td on:click={(evt) => start_edit_fn(evt, d.date)} class={(d.filler) ? "filler" : ""}>
+      {d.body}
+    </td>
+    {/each}
+  </tr>
+  {/each}
+</tbody>
+</Table>

--- a/svelte/src/lib/techs/events.svelte
+++ b/svelte/src/lib/techs/events.svelte
@@ -6,14 +6,20 @@ import { ListGroup, ListGroupItem, Button, Card, CardHeader, CardTitle, CardSubt
 import FetchError from '../fetch_error.svelte';
 import {post, get} from '$lib/api.ts';
 
+export let visible;
+let loaded = false;
 export let user;
 let loading = false;
 let promise = new Promise((r,_)=>{r([])});
 function reload() {
   loading = true;
-  promise = get('/techs/events').finally(() => loading = false);
+  promise = get('/techs/events').then((data) => {loaded=true; return data;}).finally(() => loading = false);
 }
-onMount(reload);
+$: {
+  if (visible && !loaded) {
+    reload();
+  }
+}
 
 let submitting = false;
 let submission = new Promise((r, _) => r(null));
@@ -26,6 +32,7 @@ function action(event_id, ticket_id, action) {
 }
 </script>
 
+{#if visible}
 <Card>
 <CardHeader>
   <CardTitle>Events for Backfill</CardTitle>
@@ -76,3 +83,4 @@ function action(event_id, ticket_id, action) {
     {/await}
 </CardBody>
 </Card>
+{/if}

--- a/svelte/src/lib/techs/forecast_override.svelte
+++ b/svelte/src/lib/techs/forecast_override.svelte
@@ -61,9 +61,10 @@ function revert() {
 
 <Modal isOpen={edit} header="{edit && edit.date} {edit && edit.ap}">
 <ModalBody>
+{#if edit}
   Current shift:
   <ListGroup>
-  {#if edit && edit.techs.length == 0}
+  {#if edit.techs.length == 0}
     No techs on shift
   {/if}
   {#each edit.techs as t}
@@ -96,7 +97,7 @@ function revert() {
     </ListGroupItem>
     {/if}
   </ListGroup>
-
+{/if}
 </ModalBody>
 <ModalFooter>
   <div style="width: 100%">

--- a/svelte/src/lib/techs/shifts.svelte
+++ b/svelte/src/lib/techs/shifts.svelte
@@ -3,20 +3,51 @@
 import {onMount} from 'svelte';
 import { Table, Accordion, AccordionItem, Button, Row, Container, Col, Card, CardHeader, CardTitle, Modal, CardSubtitle, CardText, Icon, Tooltip, CardFooter, CardBody, Input, Spinner, FormGroup, Navbar, NavbarBrand, Nav, NavItem, Toast, ToastBody, ToastHeader } from '@sveltestrap/sveltestrap';
 import Editor from './forecast_override.svelte';
+import Calendar from './calendar.svelte';
 import FetchError from '../fetch_error.svelte';
-import {get, post} from '$lib/api.ts';
+import {get, post, isodate} from '$lib/api.ts';
 
 export let user;
-let promise = new Promise((resolve) => {});
+export let visible;
+let loaded = false;
+let promise = new Promise((resolve) => {calendar_view: [{
+  filler: false,
+  date: "2024-12-01",
+  techs: ["a", "b"],
+  edited: false,
+}]});
 function refresh() {
-  promise = get("/techs/forecast");
+  promise = get("/techs/forecast").then((data) => {
+    loaded = true;
+
+    // Left pad data until we hit a Sunday
+    if (!data.calendar_view) {
+      return [];
+    }
+    const cal = data.calendar_view;
+    let d = new Date(cal[0].date);
+    while (d.getUTCDay() !== 0) {
+      d.setDate(d.getDate() - 1);
+      cal.unshift({date: isodate(d), filler: true});
+    }
+    d = new Date(cal[cal.length-1].date);
+    while (d.getUTCDay() !== 6) {
+      d.setDate(d.getDate() + 1);
+      cal.push({date: isodate(d), filler: true});
+    }
+    return cal;
+  });
 }
-onMount(refresh);
+$: {
+  if (visible && !loaded) {
+    refresh();
+  }
+}
 
 let edit = null;
 
-function start_edit(s) {
- let e = {ap: s.ap, date: s.date, techs: s.people, ...user};
+function start_edit(s, ap) {
+ let e = {ap: ap, date: s.date, techs: s.people, ...user};
  if (s.ovr) {
    e = {...e, id: s.ovr.id, orig: s.ovr.orig, editor: s.ovr.editor};
  }
@@ -25,6 +56,20 @@ function start_edit(s) {
 
 </script>
 
+<style>
+.calendar {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+.header {
+  text-align: center;
+}
+.filler {
+  background-color: #EEE;
+}
+</style>
+
+{#if visible}
 <Card>
   <CardHeader>
   <CardTitle>Calendar</CardTitle>
@@ -34,28 +79,37 @@ function start_edit(s) {
 {#await promise}
 	<Spinner/>Loading...
 {:then p}
-  <div class="d-flex flex-wrap">
-	{#each p.calendar_view as cv}
-	<div class="my-4" width="120px">
-		{#each cv as v}
-		<div class="mx-2">
-		  <Button id={v.id} class="p-2 mx-2" color={v.color} on:click={() => start_edit(v)}>
-		  {#if v.ovr}*{/if}
-		  {v.title}
-		  </Button>
-		</div>
-		<Tooltip target={v.id} placement="top">
-		  {#if v.people.length === 0}
-			Nobody is on shift!
-		  {:else}
-			{#each v.people as ppl}<div>{ppl}</div>{/each}
-		  {/if}
-		</Tooltip>
-		{/each}
-	</div>
-	{/each}
+  <div class="calendar">
+  <div class="header">Sun</div>
+  <div class="header">Mon</div>
+  <div class="header">Tue</div>
+  <div class="header">Wed</div>
+  <div class="header">Thu</div>
+  <div class="header">Fri</div>
+  <div class="header">Sat</div>
+	{#each p as v}
+  {#if v.filler}
+    <div class="filler"></div>
+  {:else}
+    <Card class="day">
+      <CardHeader><CardTitle>{v.date}</CardTitle></CardHeader>
+      <CardBody>
+      {#each ["AM", "PM"] as ap}
+      <h5>{ap}</h5>
+      <Button id={v[ap].id} class="p-2 mx-2" color={v[ap].color} on:click={() => start_edit(v, ap)}>
+      {#if v[ap].ovr}*{/if}
+      {#if v[ap].people.length === 0}
+        Nobody on shift!
+      {:else}
+        {#each v[ap].people as ppl}<div>{ppl}</div>{/each}
+      {/if}
+      </Button>
+      {/each}
+      </CardBody>
+    </Card>
+  {/if}
+  {/each}
   </div>
-
 {:catch error}
   <FetchError {error}/>
 {/await}
@@ -71,5 +125,6 @@ function start_edit(s) {
   <p><em>* indicates overridden shift info</em></p>
 </CardFooter>
 </Card>
+{/if}
 
 <Editor {edit} on_update={refresh}/>

--- a/svelte/src/lib/techs/shifts.svelte
+++ b/svelte/src/lib/techs/shifts.svelte
@@ -1,7 +1,7 @@
 <script type="typescript">
 
 import {onMount} from 'svelte';
-import { Table, Accordion, AccordionItem, Button, Row, Container, Col, Card, CardHeader, CardTitle, Modal, CardSubtitle, CardText, Icon, Tooltip, CardFooter, CardBody, Input, Spinner, FormGroup, Navbar, NavbarBrand, Nav, NavItem, Toast, ToastBody, ToastHeader } from '@sveltestrap/sveltestrap';
+import { Table, Label, Accordion, AccordionItem, Button, Row, Container, Col, Card, CardHeader, CardTitle, Modal, CardSubtitle, CardText, Icon, Tooltip, CardFooter, CardBody, Input, Spinner, FormGroup, Navbar, NavbarBrand, Nav, NavItem, Toast, ToastBody, ToastHeader } from '@sveltestrap/sveltestrap';
 import Editor from './forecast_override.svelte';
 import Calendar from './calendar.svelte';
 import FetchError from '../fetch_error.svelte';
@@ -9,6 +9,19 @@ import {get, post, isodate} from '$lib/api.ts';
 
 export let user;
 export let visible;
+
+const DEFAULT_DURATION = 14;
+
+let start_date = isodate(new Date());
+let end_date = new Date(start_date);
+end_date.setDate(end_date.getDate() + DEFAULT_DURATION);
+end_date = isodate(end_date);
+
+function days_between(d1, d2) {
+  // https://stackoverflow.com/a/2627493
+  return Math.round(Math.abs((new Date(end_date) - new Date(start_date)) / (24*60*60*1000)));
+}
+
 let loaded = false;
 let promise = new Promise((resolve) => {calendar_view: [{
   filler: false,
@@ -17,7 +30,8 @@ let promise = new Promise((resolve) => {calendar_view: [{
   edited: false,
 }]});
 function refresh() {
-  promise = get("/techs/forecast").then((data) => {
+  const diff_days = days_between(start_date, end_date) + 1; // Inclusive
+  promise = get(`/techs/forecast?date=${isodate(start_date)}&days=${diff_days}`).then((data) => {
     loaded = true;
 
     // Left pad data until we hit a Sunday
@@ -38,6 +52,31 @@ function refresh() {
     return cal;
   });
 }
+function date_changed(was_start) {
+  console.log("date_changed");
+  let fix = null;
+  let start = new Date(start_date);
+  let end = new Date(end_date);
+  if (!end || end < start) {
+    fix = DEFAULT_DURATION;
+  } else if (days_between(start_date, end_date) > 60) {
+    fix = 60;
+  }
+
+  if (fix) {
+    console.log("fix", fix);
+    if (was_start) {
+      end_date = new Date(start_date);
+      end_date.setDate(end_date.getDate() + fix);
+      end_date = isodate(end_date);
+    } else {
+      start_date = new Date(end_date);
+      start_date.setDate(start_date.getDate() - fix);
+      start_date = isodate(start_date);
+    }
+  }
+  refresh();
+}
 $: {
   if (visible && !loaded) {
     refresh();
@@ -47,11 +86,12 @@ $: {
 let edit = null;
 
 function start_edit(s, ap) {
- let e = {ap: ap, date: s.date, techs: s.people, ...user};
- if (s.ovr) {
-   e = {...e, id: s.ovr.id, orig: s.ovr.orig, editor: s.ovr.editor};
+  console.log(s, ap);
+ let e = {ap: ap, date: s.date, techs: s[ap].people, ...user};
+ if (s[ap].ovr) {
+   e = {...e, id: s[ap].ovr.id, orig: s[ap].ovr.orig, editor: s[ap].ovr.editor};
  }
-  edit = e;
+ edit = e;
 }
 
 </script>
@@ -59,10 +99,17 @@ function start_edit(s, ap) {
 <style>
 .calendar {
   display: grid;
+  gap: 5px;
   grid-template-columns: repeat(7, 1fr);
+  @media (max-width: 920px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 .header {
   text-align: center;
+  @media (max-width: 920px) {
+    display: none;
+  }
 }
 .filler {
   background-color: #EEE;
@@ -76,6 +123,15 @@ function start_edit(s, ap) {
   <p>An editable forecast of upcoming shifts.</p>
   </CardHeader>
 <CardBody>
+  <FormGroup>
+    <Label>Start Date</Label>
+    <Input type="date" bind:value={start_date} on:change={() => date_changed(true)}/>
+  </FormGroup>
+  <FormGroup>
+    <Label>End Date</Label>
+    <Input type="date" bind:value={end_date} on:change={() => date_changed(false)}/>
+  </FormGroup>
+
 {#await promise}
 	<Spinner/>Loading...
 {:then p}
@@ -92,20 +148,19 @@ function start_edit(s, ap) {
     <div class="filler"></div>
   {:else}
     <Card class="day">
-      <CardHeader><CardTitle>{v.date}</CardTitle></CardHeader>
-      <CardBody>
+      <div>{v.date}</div>
+      <div class="my-2">
       {#each ["AM", "PM"] as ap}
-      <h5>{ap}</h5>
+      <div>{#if v[ap].ovr}*{/if}{ap}</div>
       <Button id={v[ap].id} class="p-2 mx-2" color={v[ap].color} on:click={() => start_edit(v, ap)}>
-      {#if v[ap].ovr}*{/if}
       {#if v[ap].people.length === 0}
         Nobody on shift!
       {:else}
-        {#each v[ap].people as ppl}<div>{ppl}</div>{/each}
+        {#each v[ap].people as ppl}<div class="my-2">{ppl}</div>{/each}
       {/if}
       </Button>
       {/each}
-      </CardBody>
+      </div>
     </Card>
   {/if}
   {/each}

--- a/svelte/src/lib/techs/storage.svelte
+++ b/svelte/src/lib/techs/storage.svelte
@@ -6,6 +6,7 @@ import { ListGroup, ListGroupItem, Button, Card, CardHeader, CardTitle, CardSubt
 import FetchError from '../fetch_error.svelte';
 import {post} from '$lib/api.ts';
 
+export let visible;
 let search = "";
 let searching = false;
 let promise = new Promise((r,_)=>{r([])});
@@ -16,6 +17,7 @@ function search_member() {
 
 </script>
 
+{#if visible}
 <Card>
 <CardHeader>
   <CardTitle>Storage Violations</CardTitle>
@@ -46,3 +48,4 @@ function search_member() {
     {/await}
 </CardBody>
 </Card>
+{/if}

--- a/svelte/src/lib/techs/techs_list.svelte
+++ b/svelte/src/lib/techs/techs_list.svelte
@@ -7,6 +7,8 @@ import FetchError from '../fetch_error.svelte';
 
 import EditCell from './editable_td.svelte';
 
+export let visible;
+let loaded = false;
 let promise = new Promise((resolve) => {});
 
 let new_tech_email = "";
@@ -14,9 +16,13 @@ let toast_msg = null;
 let enrolling = false;
 
 function refresh() {
-  promise = get("/techs/list");
+  promise = get("/techs/list").then((data) => {loaded = true; return data;});
 }
-onMount(refresh);
+$: {
+  if (visible && !loaded) {
+    refresh();
+  }
+}
 
 let show_proposed = true;
 
@@ -50,7 +56,7 @@ function clearance_click(id) {
 }
 </script>
 
-
+{#if visible}
 <Card>
     <CardHeader>
       <CardTitle>Tech Roster</CardTitle>
@@ -108,3 +114,4 @@ function clearance_click(id) {
 {/await}
 </CardBody>
 </Card>
+{/if}

--- a/svelte/src/lib/techs/tool_state.svelte
+++ b/svelte/src/lib/techs/tool_state.svelte
@@ -4,9 +4,11 @@ import {onMount} from 'svelte';
 import { Table, Button, Row, Col, Card, CardHeader, Badge, CardTitle, Popover, Modal, CardSubtitle, CardText, Icon, Tooltip, CardFooter, CardBody, Input, Spinner, FormGroup, Navbar, NavbarBrand, Nav, NavItem, Toast, ToastBody, ToastHeader } from '@sveltestrap/sveltestrap';
 import {get} from '$lib/api.ts';
 
+export let visible;
+let loaded = false;
 let promise = new Promise((resolve) => {});
 function refresh() {
-  promise = get("/techs/tool_state");
+  promise = get("/techs/tool_state").then((data) => {loaded = true; return data;});
 }
 function get_color(status) {
   if (status.startsWith('Blue')) {
@@ -19,10 +21,14 @@ function get_color(status) {
   return 'light';
 }
 
-onMount(refresh);
+$: {
+  if (visible && !loaded) {
+    refresh();
+  }
+}
 </script>
 
-
+{#if visible}
 <Card>
     <CardHeader><CardTitle>Tool Maintenance State</CardTitle>
     <CardSubtitle>Click on a tool to see details and make reports</CardSubtitle>
@@ -53,3 +59,4 @@ onMount(refresh);
       Looking for a task? Check the <a href="https://app.asana.com/0/1202469740885594/1204138662113052" target="_blank">Shop & Maintenance Tasks<a/> Asana project.
   </CardFooter>
 </Card>
+{/if}

--- a/svelte/src/routes/techs/+page.svelte
+++ b/svelte/src/routes/techs/+page.svelte
@@ -1,7 +1,7 @@
 <script type="typescript">
   import '../../app.scss';
   import FetchError from '$lib/fetch_error.svelte';
-  import { TabContent, TabPane, Spinner, Row, Card, Container, Navbar, NavItem, NavbarBrand, NavLink, Nav } from '@sveltestrap/sveltestrap';
+  import { Spinner, Row, Card, Container, Navbar, NavItem, NavbarBrand, NavLink, Nav } from '@sveltestrap/sveltestrap';
   import {get} from '$lib/api.ts';
   import TechsList from '$lib/techs/techs_list.svelte';
   import ToolState from '$lib/techs/tool_state.svelte';
@@ -14,7 +14,10 @@
 
   let promise;
   let user;
+  let activeTab;
   onMount(() => {
+    activeTab = (window.location.hash || "#cal").substring(1).trim();
+    console.log("active", activeTab);
     const urlParams = new URLSearchParams(window.location.search);
     let e= urlParams.get("email");
     if (!e) {
@@ -31,6 +34,11 @@
       promise = Promise.resolve(user);
     }
   });
+  function on_tab(e) {
+    activeTab = e.target.href.split("#")[1] || "cal";
+    window.location.hash = activeTab;
+    console.log("activeTab", activeTab);
+  }
 
 </script>
 
@@ -50,33 +58,25 @@
     </NavItem>
   </Nav>
 </Navbar>
-<TabContent>
-  <!--Note: TabPanes are listed here instead of within the sub-components because
-      they are rendered twice inside of TabContent - once for the tab and once for
-      the body. This would cause multiple onMount() executions and double the number
-      of requests to the server.-->
-  <TabPane tabId="schedule" tab="Cal" active>
-  <Shifts {user}/>
-  </TabPane>
-  <TabPane tabId="assignments" tab="Shifts" active>
-    <Assignments/>
-  </TabPane>
-  <TabPane tabId="tools" tab="Tools">
-    <ToolState/>
-  </TabPane>
-  <TabPane tabId="storage" tab="Storage">
-    <Storage/>
-  </TabPane>
-  <TabPane tabId="area_leads" tab="Areas">
-    <AreaLeads/>
-  </TabPane>
-  <TabPane tabId="techs" tab="Techs">
-    <TechsList/>
-  </TabPane>
-  <TabPane tabId="events" tab="Events">
-    <Events {user}/>
-  </TabPane>
-</TabContent>
+<!-- Note: Nav is used here instead of Tabs directly because Tabs does not
+     support URL anchor based routing - see
+     https://github.com/sveltestrap/sveltestrap/issues/82 -->
+<Nav tabs>
+  <NavItem><NavLink href="#cal" on:click={on_tab}>Cal</NavLink></NavItem>
+  <NavItem><NavLink href="#shifts" on:click={on_tab}>Shifts</NavLink></NavItem>
+  <NavItem><NavLink href="#tools" on:click={on_tab}>Tools</NavLink></NavItem>
+  <NavItem><NavLink href="#storage" on:click={on_tab}>Storage</NavLink></NavItem>
+  <NavItem><NavLink href="#areas" on:click={on_tab}>Areas</NavLink></NavItem>
+  <NavItem><NavLink href="#techs" on:click={on_tab}>Techs</NavLink></NavItem>
+  <NavItem><NavLink href="#events" on:click={on_tab}>Events</NavLink></NavItem>
+</Nav>
+<Shifts {user} visible={activeTab == 'cal'}/>
+<Assignments visible={activeTab == 'shifts'}/>
+<ToolState visible={activeTab == 'tools'}/>
+<Storage visible={activeTab == 'storage'}/>
+<AreaLeads visible={activeTab == 'areas'}/>
+<TechsList visible={activeTab === 'techs'}/>
+<Events {user} visible={activeTab === 'events'}/>
 {#await promise}
   <span></span>
 {:catch error}


### PR DESCRIPTION
* Note that `footer` is now injected as a field to all template rendering, set to a link to Cronicle if running as a job otherwise None.
* Creates `sync_booked_members` command to ensure all members are properly represented in Booked. Booked user IDs are now saved as a custom field in each Neon CRM account, to allow for users to change their name & email without breaking sync with Booked.
* Fixed multiple breaking bugs with membership activation via Neon webhook - source data was formatted differently than the API doc, and account ID was used instead of membership ID when activating membership. Now fixed.
* Add percentage reporting for Cronicle job execution of CLI commands
* added `YAML_OUT` environment var for retargeting yaml output of CLI functions
* Added date range controls and generally improved UX of tech forecast/calendar
* Switched tech tabs to load-on-view