### PR TITLE
Fix bug in scheduler; re-enable 1pm/2pm scheduling

### DIFF
--- a/protohaven_api/automation/classes/scheduler.py
+++ b/protohaven_api/automation/classes/scheduler.py
@@ -1,4 +1,5 @@
 """ Methods for scheduling new classes """
+
 import datetime
 import logging
 from collections import defaultdict
@@ -40,7 +41,7 @@ def slice_date_range(start_date: datetime, end_date: datetime, class_duration: i
     # Would be best to switch to time-bucketed scheduling that would allow for
     # more variety of classes without hard-constraiing start times to prevent
     # overlaps.
-    day_class_hours = [10, 14, 18]
+    day_class_hours = [10, 13, 14, 18]
     evening_threshold = 17
     evening_only_days = {0, 1, 2, 3, 4}  # Monday is 0, Sunday is 6
     ret = []

--- a/protohaven_api/automation/classes/solver.py
+++ b/protohaven_api/automation/classes/solver.py
@@ -1,4 +1,5 @@
 """Solves class scheduling problems given an environment containing Classes and Instructors"""
+
 # https://stackoverflow.com/questions/42450533/bin-packing-python-query-with-variable-people-cost-and-sizes
 # https://gist.github.com/sameerkumar18/086cc6bdc277dc1cefb4374fa7b0327a
 import datetime
@@ -88,7 +89,7 @@ class Instructor:
         self.rejected = rejected or {}
 
     def __repr__(self):
-        return f"{self.name} (caps={len(self.caps)}, times={len(self.avail)}"
+        return f"{self.name} (caps={len(self.caps)}, times={len(self.avail)})"
 
     def as_dict(self):
         """Return instructor as a dict"""
@@ -110,9 +111,19 @@ def _find_overlap(c1, t1, c2, t2):
     return False
 
 
-def get_overlapping(c1, t1, classes, times):
+def get_overlapping_by_time(c1, t1, classes, times):
     """Yields a sequence of (class_id, start_time) of classes that would
-    conflict with class `c` running at time `t`.
+    conflict with class `c1` running at time `t1`.
+    Note that duplicate values may be returned."""
+    for c2 in classes:
+        for t2 in times:
+            if _find_overlap(c1, t1, c2, t2):
+                yield c2.class_id, t2
+
+
+def get_overlapping_by_area(c1, t1, classes, times):
+    """Yields a sequence of (class_id, start_time) of classes that would
+    conflict with class `c1` running at time `t1` in the same area.
     Note that duplicate values may be returned."""
     for c2 in classes:
         # Classes without intersecting areas don't have a chance of overlapping
@@ -180,7 +191,17 @@ def solve(classes, instructors):  # pylint: disable=too-many-locals,too-many-bra
         for class_id in i.caps:
             c = class_by_id.get(class_id)
             for t in i.avail:
-                overlaps = set(get_overlapping(c, t, class_by_id.values(), times))
+                # Across all listed classes and availabilities in the environment,
+                # fetch the unique combos of (class_id, start_time) which would
+                # overlap with class `c` running at time `t` in the same area.
+                #
+                # NOTE: Classes running in different areas aren't considered overlapping,
+                # even if the same instructor is teaching them at an overlapping time. This is
+                # why the "Instructor teach at most 1 class" constraint below is important.
+                overlaps = set(
+                    get_overlapping_by_area(c, t, class_by_id.values(), times)
+                )
+
                 # Include all instructors that could teach each
                 # overlap at the computed start time
                 area_assigned_times = pulp.lpSum(
@@ -198,7 +219,9 @@ def solve(classes, instructors):  # pylint: disable=too-many-locals,too-many-bra
                     f"NoOverlapRequirement_{i.name}_{class_id}_{t}",
                 )
 
-    # Classes run at most once
+    # Classes run at most once during the time period.
+    # The linear solver would happily schedule infinite classes at the same time
+    # without this constraint being made explicit.
     for cls in classes:
         class_assigned_count = pulp.lpSum(
             [
@@ -211,21 +234,25 @@ def solve(classes, instructors):  # pylint: disable=too-many-locals,too-many-bra
         )
         prob += (class_assigned_count <= 1), f"NoDuplicatesRequirement_{cls.class_id}"
 
-    # Instructors teach at most 1 class at any given time
-    for p in instructors:
-        for t in p.avail:
-            booking_count = pulp.lpSum(
-                [
-                    x[(cls.class_id, p.name, t)]
-                    for cls in classes
-                    if cls.class_id in p.caps
-                    and x.get((cls.class_id, p.name, t)) is not None
-                ]
-            )
-            prob += (
-                booking_count <= 1,
-                f"NoDoubleBookedInstructorRequirement_{p.name}_{t}",
-            )
+    # Instructors are not double-booked with overlapping classes.
+    for i in instructors:
+        for class_id in i.caps:
+            c = class_by_id.get(class_id)
+            for t in i.avail:
+                overlaps = set(
+                    get_overlapping_by_time(c, t, class_by_id.values(), times)
+                )
+                booking_count = pulp.lpSum(
+                    [
+                        x[(cid, i.name, start)]
+                        for cid, start in overlaps
+                        if x.get((cid, i.name, start)) is not None
+                    ]
+                )
+                prob += (
+                    booking_count <= 1,
+                    f"NoDoubleBookedInstructorRequirement_{i.name}_{class_id}_{t}",
+                )
 
     # ==== Run the solver and compute stats ====
     prob.solve()


### PR DESCRIPTION
Bug allowed instructor to schedule non-area-overlapping classes that overlap in time.