### PR TITLE
Add /techs#members tab, dedupe sign-in waiver action

### DIFF
--- a/protohaven_api/automation/membership/sign_in_test.py
+++ b/protohaven_api/automation/membership/sign_in_test.py
@@ -1,4 +1,5 @@
 """Unit tests for sign-in automation flow"""
+
 # pylint: skip-file
 
 import datetime
@@ -94,7 +95,7 @@ def test_log_sign_in(mocker):
     mocker.patch.object(s.airtable, "insert_signin", return_value="airtable_response")
     m = mocker.patch.object(s, "_apply_async")
 
-    s.log_sign_in(data, result)
+    s.log_sign_in(data, result, {})
     m.assert_called_once()
 
 
@@ -590,8 +591,10 @@ def test_as_member_announcements_ok(mocker):
             "a@b.com": {
                 12346: {
                     "Account ID": 12345,
+                    "Clearances": "Clearance A|Clearance B",
                     "Account Current Membership Status": "Active",
                     "First Name": "First",
+                    "Last Name": "Last",
                     "API server role": "Shop Tech",
                 }
             }
@@ -636,6 +639,10 @@ def test_as_member_announcements_ok(mocker):
                 referrer=None,
                 purpose="I'm a member, just signing in!",
                 am_member=True,
+                full_name="First Last",
+                clearances=["Clearance A", "Clearance B"],
+                violations=[],
+                status="Active",
             ),
         ),
     )

--- a/protohaven_api/handlers/techs.py
+++ b/protohaven_api/handlers/techs.py
@@ -104,6 +104,14 @@ def techs_shifts():
     return forecast.get_shift_map()
 
 
+@page.route("/techs/members")
+def techs_members():
+    """Fetches today's sign-in information for members"""
+    # Could extend this to search particular days...
+    start = tznow().replace(hour=0, minute=0, second=0)
+    return list(airtable.get_signins_after(start))
+
+
 @page.route("/techs/area_leads")
 def techs_area_leads():
     """Fetches the mapping of areas to area leads"""

--- a/protohaven_api/integrations/airtable.py
+++ b/protohaven_api/integrations/airtable.py
@@ -254,6 +254,12 @@ def get_all_announcements():
     return list(get_all_records("people", "sign_in_announcements"))
 
 
+def get_signins_after(after):
+    """Fetches all sign-in data after a specific datetime"""
+    for rec in get_all_records_after("people", "sign_ins", after):
+        yield rec["fields"]
+
+
 def insert_simple_survey_response(announcement_id, email, neon_id, response):
     """Insert a survey response from the welcome page into Airtable"""
     return insert_records(

--- a/protohaven_api/integrations/data/models.py
+++ b/protohaven_api/integrations/data/models.py
@@ -1,9 +1,10 @@
 """OOP-style representation of entities stored in Airtable and elsewhere"""
+
 from dataclasses import dataclass
 
 
 @dataclass
-class SignInEvent:
+class SignInEvent:  # pylint: disable=too-many-instance-attributes
     """Represents a sign-in event by a user at the /welcome form"""
 
     email: str
@@ -12,6 +13,13 @@ class SignInEvent:
     referrer: str
     purpose: str
     am_member: bool
+
+    # These fields only exist in Airtable; don't send them to Google
+    # Forms as it'll likely error.
+    full_name: str
+    clearances: list
+    violations: list
+    status: list
 
     def to_airtable(self):
         """Convert data to Airtable record format"""
@@ -22,6 +30,11 @@ class SignInEvent:
             "Referrer": self.referrer,
             "Purpose": self.purpose,
             "Am Member": self.am_member,
+            # Airtable-specific fields
+            "Full Name": self.full_name,
+            "Clearances": ", ".join(self.clearances),
+            "Violations": ", ".join(self.violations),
+            "Status": self.status,
         }
 
     def to_google_form(self):
@@ -30,11 +43,13 @@ class SignInEvent:
             "email": self.email,
             "dependent_info": self.dependent_info,
             "waiver_ack": (
-                "I have read and understand this agreement and "
-                "agree to be bound by its requirements.",  # Must be this, otherwise 400 error
-            )
-            if self.waiver_ack
-            else "",
+                (
+                    "I have read and understand this agreement and "
+                    "agree to be bound by its requirements.",  # Must be this, otherwise 400 error
+                )
+                if self.waiver_ack
+                else ""
+            ),
             "referrer": self.referrer,
             "purpose": "I'm a member, just signing in!",
             "am_member": "Yes" if self.am_member else "No",

--- a/protohaven_api/integrations/mqtt.py
+++ b/protohaven_api/integrations/mqtt.py
@@ -139,6 +139,8 @@ def get():
 
 def notify_reservation(tool_code, ref, start_time, end_time, user_id):
     """Notify that equipment is being reserved"""
+    if not client:
+        return None
     return client.pub(
         TopicResource.TOOL,
         tool_code,
@@ -154,6 +156,8 @@ def notify_reservation(tool_code, ref, start_time, end_time, user_id):
 
 def notify_maintenance(tool_code, status, reason):
     """Notify that equipment maintenance status is changing"""
+    if not client:
+        return None
     return client.pub(
         TopicResource.TOOL,
         tool_code,
@@ -164,6 +168,8 @@ def notify_maintenance(tool_code, status, reason):
 
 def notify_member_signed_in(user_id):
     """Notify that a user has signed in at the front desk"""
+    if not client:
+        return None
     return client.pub(TopicResource.USER, user_id, TopicAttribute.SIGNIN, "1")
 
 
@@ -171,6 +177,8 @@ def notify_clearance(
     user_id: str, tool_code: str, added: bool = True, level=ClearanceLevel.MEMBER
 ):
     """Notify that a user's clearance has been added or removed"""
+    if not client:
+        return None
     return client.pub(
         TopicResource.TOOL,
         tool_code,

--- a/svelte/src/lib/techs/members.svelte
+++ b/svelte/src/lib/techs/members.svelte
@@ -1,0 +1,95 @@
+<script type="typescript">
+
+import {onMount} from 'svelte';
+import { Accordion, AccordionItem, ListGroup, ListGroupItem, Button, Card, CardHeader, CardTitle, CardSubtitle, CardBody, Input, Spinner } from '@sveltestrap/sveltestrap';
+
+import FetchError from '../fetch_error.svelte';
+import {get} from '$lib/api.ts';
+
+export let visible;
+let search = "";
+let promise = new Promise((r,_)=>{r([])});
+let loaded = false;
+function refresh() {
+  promise = get(`/techs/members`).then((data) => {
+    loaded = true;
+    let results = [];
+    for (let d of data) {
+      results.push({
+        "timestamp": new Date(d['Created']),
+        "member": d['Am Member'],
+        "email": d['Email'],
+        "clearances": (d['Clearances']) ? d['Clearances'].split(',').map(entry => entry.trim()) : [],
+        "status": d['Status'] || 'UNKNOWN',
+        "name": d['Full Name'] || null,
+        "violations": (d['Violations']) ? d['Violations'].split(',').map(entry => entry.trim()): [],
+      });
+    }
+    // Sort descending, newest on top
+    results.sort((a, b) => b.timestamp - a.timestamp);
+    return results;
+  });
+}
+$: {
+  if (visible && !loaded) {
+    refresh();
+  }
+}
+
+</script>
+
+{#if visible}
+<Card>
+<CardHeader>
+  <CardTitle>Member Check</CardTitle>
+  <CardSubtitle>Today's sign-ins, including membership state and clearances</CardSubtitle>
+</CardHeader>
+<CardBody>
+    {#await promise}
+      <Spinner/>Loading...
+    {:then p}
+    <ListGroup>
+    {#each p as r}
+      <ListGroupItem>
+        <p><strong>{r.email}{#if r.name}&nbsp;({r.name}){/if}</strong></p>
+        <p> {r.timestamp.toLocaleTimeString()} -
+              {#if !r.member}
+                Guest
+              {:else}
+                  Member (<span style={(r.status !== 'Active') ? 'background-color: yellow;' : null}}>{r.status}</span>)
+              {/if}
+        </p>
+        {#if !r.clearances.length && !r.violations.length}
+          <p>No clearances, no violations</p>
+        {:else}
+          <Accordion>
+            {#if r.clearances.length}
+              <AccordionItem header={r.clearances.length + ' clearance(s)'}>
+                <ListGroup>
+                {#each r.clearances as c}
+                  <ListGroupItem>{c}</ListGroupItem>
+                {/each}
+                </ListGroup>
+              </AccordionItem>
+            {/if}
+            {#if r.violations.length}
+              <AccordionItem>
+                <p class="m-0" slot="header" style={(r.violations.length) ? 'background-color: yellow;' : null}>{r.violations.length + ' violation(s)'}</p>
+                <ListGroup>
+                {#each r.violations as v}
+                  <ListGroupItem>{v}</ListGroupItem>
+                {/each}
+                </ListGroup>
+              </AccordionItem>
+            {/if}
+          </Accordion>
+        {/if}
+      </ListGroupItem>
+    {/each}
+    </ListGroup>
+    {:catch error}
+      <FetchError {error}/>
+    {/await}
+</CardBody>
+</Card>
+{/if}

--- a/svelte/src/routes/techs/+page.svelte
+++ b/svelte/src/routes/techs/+page.svelte
@@ -6,6 +6,7 @@
   import TechsList from '$lib/techs/techs_list.svelte';
   import ToolState from '$lib/techs/tool_state.svelte';
   import Shifts from '$lib/techs/shifts.svelte';
+  import Members from '$lib/techs/members.svelte';
   import Assignments from '$lib/techs/assignments.svelte';
   import AreaLeads from '$lib/techs/area_leads.svelte';
   import Storage from '$lib/techs/storage.svelte';
@@ -63,6 +64,7 @@
      https://github.com/sveltestrap/sveltestrap/issues/82 -->
 <Nav tabs>
   <NavItem><NavLink href="#cal" on:click={on_tab}>Cal</NavLink></NavItem>
+  <NavItem><NavLink href="#members" on:click={on_tab}>Members</NavLink></NavItem>
   <NavItem><NavLink href="#shifts" on:click={on_tab}>Shifts</NavLink></NavItem>
   <NavItem><NavLink href="#tools" on:click={on_tab}>Tools</NavLink></NavItem>
   <NavItem><NavLink href="#storage" on:click={on_tab}>Storage</NavLink></NavItem>
@@ -71,6 +73,7 @@
   <NavItem><NavLink href="#events" on:click={on_tab}>Events</NavLink></NavItem>
 </Nav>
 <Shifts {user} visible={activeTab == 'cal'}/>
+<Members {user} visible={activeTab == 'members'}/>
 <Assignments visible={activeTab == 'shifts'}/>
 <ToolState visible={activeTab == 'tools'}/>
 <Storage visible={activeTab == 'storage'}/>

--- a/svelte/src/routes/welcome/+page.svelte
+++ b/svelte/src/routes/welcome/+page.svelte
@@ -106,15 +106,19 @@
     announcements = result.announcements;
     violations = result.violations;
 
+    if (person !== 'guest' && result.status !== 'Active') {
+      // Expired membership takes priority in notification
+      state = 'membership_expired';
+      return;
+    }
+
     if (!result.waiver_signed) {
       state = 'waiver';
+      return;
     }
-    else if (person == 'guest' || result.status == 'Active') {
-      state = 'signin_ok';
-    }
-    else {
-      state = 'membership_expired';
-    }
+
+    // If everything else is good, we're good.
+    state = 'signin_ok';
   }
 </script>
 

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -21,7 +21,7 @@ const PROXY_PATHS = [
   '/whoami',
   '/neon_lookup',
   '/class_listing',
-  '/welcome',
+  // '/welcome',
 ];
 const WS_PROXY_PATHS = [
   '/welcome/ws',


### PR DESCRIPTION
Previously sign-ins treated "waiver not signed" as a thing to display to users before "not a member"; this causes duplicate alerts and is unnecessary for the member (requiring them to always sign the waiver if their membership is expired)

Also added a basic member check tab to the /techs dashboard.