### PR TITLE
/techs dashboard tech-only events, plus refactors

### DIFF
--- a/protohaven_api/automation/membership/sign_in_test.py
+++ b/protohaven_api/automation/membership/sign_in_test.py
@@ -724,7 +724,14 @@ def test_as_member_company_id(mocker):
     s.notify_async.assert_not_called()
 
 
-def test_as_member_notify_board_and_staff(mocker):
+@pytest.mark.parametrize(
+    "status",
+    [
+        "Active",
+        "Inactive",
+    ],
+)
+def test_as_member_notify_board_and_staff(mocker, status):
     """Test that a discord notification is sent if the account is flagged"""
     mocker.patch.object(s, "_apply_async")
     mocker.patch.object(s, "notify_async")
@@ -735,9 +742,9 @@ def test_as_member_notify_board_and_staff(mocker):
             "a@b.com": {
                 12345: {
                     "Account ID": 12345,
-                    "Account Current Membership Status": "Active",
+                    "Account Current Membership Status": status,
                     "First Name": "First",
-                    "Notify Board & Staff": "On Sign In|Other Unrelated Condition",
+                    "Notify Board & Staff": f"On Sign In|Other Unrelated Condition",
                 },
             }
         },
@@ -753,6 +760,4 @@ def test_as_member_notify_board_and_staff(mocker):
         },
         mocker.MagicMock(),
     )
-    s.notify_async.assert_called_with(
-        "@Board and @Staff: [First (a@b.com)](https://protohaven.app.neoncrm.com/admin/accounts/12345) just signed in at the front desk with `Notify Board & Staff = On Sign In`. This indicator suggests immediate followup with this member is needed. Click the name/email link for notes in Neon CRM."
-    )
+    s.notify_async.assert_any_call(MatchStr("immediate followup with this member"))

--- a/protohaven_api/handlers/instructor.py
+++ b/protohaven_api/handlers/instructor.py
@@ -1,4 +1,5 @@
 """Handlers for instructor actions on classes"""
+
 import datetime
 import logging
 
@@ -12,7 +13,7 @@ from protohaven_api.automation.classes.scheduler import push_schedule, solve_wit
 from protohaven_api.config import tz, tznow
 from protohaven_api.handlers.auth import user_email, user_fullname
 from protohaven_api.integrations import airtable, neon, neon_base
-from protohaven_api.rbac import Role, am_admin, require_login_role
+from protohaven_api.rbac import Role, am_role, require_login_role
 
 log = logging.getLogger("handlers.instructor")
 
@@ -107,9 +108,11 @@ def get_instructor_readiness(inst, caps=None):
             x
             for x in [
                 "W9" if not caps["fields"].get("W9 Form") else None,
-                "Direct Deposit"
-                if not caps["fields"].get("Direct Deposit Info")
-                else None,
+                (
+                    "Direct Deposit"
+                    if not caps["fields"].get("Direct Deposit Info")
+                    else None
+                ),
                 "Profile Pic" if not caps["fields"].get("Profile Pic") else None,
                 "Bio" if not caps["fields"].get("Bio") else None,
             ]
@@ -202,7 +205,7 @@ def instructor_about():
     email = request.args.get("email")
     if email is not None:
         ue = user_email()
-        if ue != email and not am_admin():
+        if ue != email and not am_role(Role.ADMIN, Role.EDUCATION_LEAD, Role.STAFF):
             return Response("Access Denied for admin parameter `email`", status=401)
     else:
         email = user_email()
@@ -264,7 +267,7 @@ def instructor_class_details():
     email = request.args.get("email")
     if email is not None:
         ue = user_email()
-        if ue != email and not am_admin():
+        if ue != email and not am_role(Role.ADMIN, Role.EDUCATION_LEAD, Role.STAFF):
             return Response("Access Denied for admin parameter `email`", status=401)
     else:
         email = user_email()

--- a/protohaven_api/handlers/member.py
+++ b/protohaven_api/handlers/member.py
@@ -1,4 +1,5 @@
 """handlers for member pages"""
+
 import logging
 import threading
 
@@ -6,7 +7,7 @@ from flask import Blueprint, Response, current_app, request, session
 
 from protohaven_api.automation.roles.roles import setup_discord_user_sync
 from protohaven_api.integrations import neon
-from protohaven_api.rbac import am_admin, require_login
+from protohaven_api.rbac import Role, am_role, require_login
 
 page = Blueprint("member", __name__, template_folder="templates")
 
@@ -43,7 +44,7 @@ def set_discord_nick():
 
     if neon_id != "":
         nid = (session.get("neon_id") or "").strip()
-        if nid != neon_id and not am_admin():
+        if nid != neon_id and not am_role(Role.ADMIN):
             return Response("Access Denied for admin parameter `neon_id`", status=401)
     result = neon.set_discord_user(neon_id, discord_id)
     if not result.get("accountId") == str(neon_id):

--- a/protohaven_api/integrations/booked.py
+++ b/protohaven_api/integrations/booked.py
@@ -102,6 +102,13 @@ def get_reservations(start, end):
     return get_connector().booked_request("GET", url)
 
 
+def delete_reservation(refnum):
+    """Deletes a reservation by its reference number - be very careful with
+    this one!"""
+    url = f"/Reservations/{refnum}"
+    return get_connector().booked_request("DELETE", url)
+
+
 def reserve_resource(
     resource_id,
     start_time,

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -492,7 +492,8 @@ def update_account_automation_run_status(account_id, status: str, now=None):
 
 
 def set_event_scheduled_state(neon_id, scheduled=True):
-    """Publishes or unpublishes an event in Neon"""
+    """Publishes or unpublishes an event in Neon, including registration
+    and public visibility in protohaven.org/classes/"""
     return neon_base.patch(
         "api_key3",
         f"/events/{neon_id}",

--- a/protohaven_api/integrations/neon_base.py
+++ b/protohaven_api/integrations/neon_base.py
@@ -548,6 +548,7 @@ def create_event(  # pylint: disable=too-many-arguments
     dry_run=True,
     published=True,
     registration=True,
+    free=False,
 ):
     """Creates a new event in Neon CRM"""
     event = {
@@ -571,7 +572,7 @@ def create_event(  # pylint: disable=too-many-arguments
             "timeZone": {"id": "1"},
         },
         "financialSettings": {
-            "feeType": "MT_OA",
+            "feeType": "Free" if free else "MT_OA",
             "admissionFee": None,
             "ticketsPerRegistration": None,
             "fund": None,

--- a/protohaven_api/rbac.py
+++ b/protohaven_api/rbac.py
@@ -151,6 +151,6 @@ def require_login_role(*role):
     return fn_setup
 
 
-def am_admin():
-    """Returns True if the current session is an administrator"""
-    return require_login_role(Role.ADMIN)(lambda: True)() is True
+def am_role(*role):
+    """Returns True if the current session is one of the roles provided"""
+    return require_login_role(*role)(lambda: True)() is True

--- a/protohaven_api/rbac.py
+++ b/protohaven_api/rbac.py
@@ -132,10 +132,13 @@ def require_login_role(*role):
                 session["redirect_to_login_url"] = request.url
                 return redirect(url_for("auth.login_user_neon_oauth"))
             # Check for presence of role. Note that shop techs are a special case; leads can do
-            # anything that a shop tech is allowed to do
+            # anything that a shop tech is allowed to do.
+            # Admins can also do anything.
             for r in role:
-                if r["name"] in roles or (
-                    r == Role.SHOP_TECH and Role.SHOP_TECH_LEAD["name"] in roles
+                if (
+                    r["name"] in roles
+                    or (r == Role.SHOP_TECH and Role.SHOP_TECH_LEAD["name"] in roles)
+                    or Role.ADMIN["name"] in roles
                 ):
                     return fn(*args, **kwargs)
 
@@ -153,4 +156,4 @@ def require_login_role(*role):
 
 def am_role(*role):
     """Returns True if the current session is one of the roles provided"""
-    return require_login_role(*role)(lambda: True)() is True
+    return (not is_enabled()) or require_login_role(*role)(lambda: True)() is True

--- a/protohaven_api/rbac_test.py
+++ b/protohaven_api/rbac_test.py
@@ -109,3 +109,17 @@ def test_get_roles(
     )
 
     assert rbac.get_roles() == expected_roles
+
+
+def test_am_role(mocker):
+    """Test am_role function"""
+    mocker.patch.object(rbac, "is_enabled", return_value=False)
+    assert rbac.am_role(Role.ADMIN) is True
+
+    mocker.patch.object(rbac, "is_enabled", return_value=True)
+    mocker.patch.object(rbac, "get_roles", return_value=[Role.ADMIN["name"]])
+    assert rbac.am_role(Role.ADMIN) is True
+
+    mocker.patch.object(rbac, "is_enabled", return_value=True)
+    mocker.patch.object(rbac, "get_roles", return_value=["not_admin"])
+    assert rbac.am_role(Role.ADMIN) is False

--- a/svelte/src/lib/techs/events.svelte
+++ b/svelte/src/lib/techs/events.svelte
@@ -1,7 +1,7 @@
 <script type="typescript">
 
 import {onMount} from 'svelte';
-import { ListGroup, ListGroupItem, Button, Card, CardHeader, CardTitle, CardSubtitle, CardBody, Input, Spinner } from '@sveltestrap/sveltestrap';
+import { Row, Col, Form, FormGroup, ListGroup, ListGroupItem, Button, Card, CardHeader, CardTitle, CardSubtitle, CardBody, Input, Spinner } from '@sveltestrap/sveltestrap';
 
 import FetchError from '../fetch_error.svelte';
 import {post, get} from '$lib/api.ts';
@@ -30,6 +30,47 @@ function action(event_id, ticket_id, action) {
     submitting = false;
   });
 }
+
+let new_event_form = {
+  "name": null,
+  "capacity": 6,
+  "start": null,
+  "hours": 3,
+};
+function new_tech_event() {
+  if (!new_event_form.name || !new_event_form.name.trim().length) {
+    alert("Please name your tech class");
+    return;
+  }
+  let d = new Date(new_event_form.start);
+  if (d < new Date()) {
+    alert("Start date must be set, and in the future");
+    return;
+  }
+  if (d.getHours() < 10 || d.getHours() + new_event_form.hours > 22) {
+    alert("Event must start and end within shop hours (10AM-10PM); please check date and hours form values");
+    return;
+  }
+  console.log("Create event", new_event_form);
+  submitting = true;
+  submission = post('/techs/new_event', new_event_form).then(result => {
+    console.log(result);
+  }).finally(() => {
+    reload();
+    submitting = false;
+  });
+}
+
+function delete_event(eid) {
+  submitting = true;
+  submission = post('/techs/rm_event', {eid}).then(result => {
+    console.log(result);
+  }).finally(() => {
+    reload();
+    submitting = false;
+  });
+}
+
 </script>
 
 {#if visible}
@@ -40,7 +81,7 @@ function action(event_id, ticket_id, action) {
 </CardHeader>
 <CardBody>
     <p>Note: you will need to pay the cost of materials when you show up.</p>
-    <p>You can pay at the front desk via Square (select "Walk-In (3 Hr Class / add price)", set to the cost listed above, charge as normal)</p>
+    <p>You can pay at the front desk via Square - select "Walk-In (3 Hr Class / add price)", set to the cost listed above, charge as normal.</p>
     {#if !user }
       <p><strong>You must <a href="http://api.protohaven.org/login">login</a> to register.</strong></p>
     {:else}
@@ -62,7 +103,7 @@ function action(event_id, ticket_id, action) {
     {#if p.length === 0}
       <em>No event available for backfill - please check back later.</em>
     {/if}
-    {#each p as r}
+    {#each p.events as r}
       <ListGroupItem>
             <div><strong>{r.name}</strong></div>
             <div>On {new Date(r.start).toLocaleString()}</div>
@@ -70,17 +111,59 @@ function action(event_id, ticket_id, action) {
             <div>{r.capacity - r.attendees.length} seat(s) left</div>
             {#if user}
             <div>
-            {#if r.attendees.indexOf(user.neon_id) !== -1}
+            {#if r.attendees.indexOf(user.neon_id) !== -1 && r.capacity - r.attendees.length > 0}
               <strong>You are registered!</strong>
               <Button color="secondary" on:click={()=>action(r.id, r.ticket_id, 'unregister')} disabled={submitting}>Unregister</Button>
             {:else}
               <Button color="primary" on:click={()=>action(r.id, r.ticket_id, 'register')} disabled={submitting}>Register</Button>
+            {/if}
+            {#if p.tech_lead && r.name.startsWith("(SHOP TECH ONLY)")}
+              <Button color="secondary" class="mx-4" on:click={()=>delete_event(r.id)}>Delete Permanently</Button>
             {/if}
             </div>
             {/if}
       </ListGroupItem>
     {/each}
     </ListGroup>
+
+    {#if p.tech_lead}
+    <h4 class="my-2">Create a new event for techs</h4>
+    <p>Note: this event is unlisted and will not appear on the <a href="protohaven.org/classes/">Classes and Events</a> page. Event creation is only visible to logged-in users with the Tech Leads role set in Neon CRM.</p>
+
+    <Form>
+      <FormGroup>
+        <Row>
+          <Col md="6">
+            <span>Class name:</span>
+            <Input type="text" id="class_name" label="Class Name" bind:value={new_event_form.name} />
+          </Col>
+          <Col md="6">
+            <span>Max participants:</span>
+            <Input type="number" id="capacity" label="Capacity" bind:value={new_event_form.capacity}/>
+          </Col>
+        </Row>
+        <Row>
+          <Col md="6">
+            <span>Start date and time:</span>
+            <Input type="datetime-local" id="start" label="Start Time" bind:value={new_event_form.start}/>
+          </Col>
+          <Col md="6">
+            <span>Duration (hours)</span>
+            <Input type="number" id="hours" label="Duration (hours)" bind:value={new_event_form.hours}/>
+          </Col>
+        </Row>
+        <Row>
+          <Col md="12" class="d-flex justify-content-end">
+            <Button on:click={new_tech_event} type="submit" color="primary">Submit</Button>
+          </Col>
+        </Row>
+      </FormGroup>
+    </Form>
+
+    <hr/>
+    {/if}
+
+
     {:catch error}
       <FetchError {error}/>
     {/await}

--- a/svelte/src/routes/techs/+page.svelte
+++ b/svelte/src/routes/techs/+page.svelte
@@ -47,6 +47,9 @@
   <NavbarBrand>Techs Dashboard</NavbarBrand>
   <Nav>
     <NavItem>
+      <NavLink href="/events" target="_blank">Events Dashboard</NavLink>
+    </NavItem>
+    <NavItem>
       <NavLink href="https://wiki.protohaven.org/shelves/shop-techs" target="_blank">Wiki</NavLink>
     </NavItem>
     <NavItem>


### PR DESCRIPTION
* Edu leads and staff now have instructor page admin powers
* Add tech event creation/deletion by leads
* Improve logic for backfill class presentation
* Refactor tests and rbac 'am_role'
* Add events dashboard link to /techs