### PR TITLE
callout to neon on cache miss; fmt tech tasks msg; no load secrets when dev

### DIFF
--- a/protohaven_api/automation/membership/sign_in_test.py
+++ b/protohaven_api/automation/membership/sign_in_test.py
@@ -398,7 +398,7 @@ def test_as_guest_referrer(mocker):
 def test_as_member_notfound(mocker):
     """Ensure form does not get called if member not found"""
     m = mocker.patch.object(s, "_apply_async")
-    s.neon.search_member.return_value = []
+    mocker.patch.object(s.neon, "search_member", return_value=[])
     got = s.as_member(
         {
             "person": "member",

--- a/protohaven_api/config.py
+++ b/protohaven_api/config.py
@@ -1,4 +1,5 @@
 """Loads config.yaml"""
+
 import datetime
 import os
 import pickle
@@ -45,7 +46,11 @@ def load_yaml_with_env_substitution(yaml_path):
     # Apply defaults, followed by secrets, followed by ENV overrides
     env = {
         **dotenv_values(ENV_DEFAULTS_PATH),
-        **dotenv_values(ENV_SECRETS_PATH),
+        **(
+            dotenv_values(ENV_SECRETS_PATH)
+            if not os.getenv("PH_SERVER_MODE") == "dev"
+            else {}
+        ),
         **dict(os.environ),
     }
 

--- a/protohaven_api/integrations/comms_test.py
+++ b/protohaven_api/integrations/comms_test.py
@@ -415,7 +415,7 @@ HASHES = {
     "shop_tech_applications": "815a9680858772a4",  # pragma: allowlist secret
     "square_validation_action_needed": "3ed4e73c9efa37db",  # pragma: allowlist secret
     "stale_purchase_requests": "eafac3a7e4553a83",  # pragma: allowlist secret
-    "tech_daily_tasks": "29af31c3b72f00ec",  # pragma: allowlist secret
+    "tech_daily_tasks": "40fd5ae5ea4d2806",  # pragma: allowlist secret
     "tech_leads_maintenance_status": "e763f572fa0203a5",  # pragma: allowlist secret
     "tech_openings": "6212e17a71640d10",  # pragma: allowlist secret
     "tool_documentation": "30faa1dfb4e04a20",  # pragma: allowlist secret

--- a/protohaven_api/integrations/templates/tech_daily_tasks.jinja2
+++ b/protohaven_api/integrations/templates/tech_daily_tasks.jinja2
@@ -1,4 +1,5 @@
 {% if subject %}{{salutation}} {% if new_count > 0 %}Today we have {{new_count}} new tech_ready task{% if new_count != 1 %}s{% endif %}:{% else %}There are no new tasks for today - we're caught up on scheduling!{% endif %}
 {% else %}{% for t in new_tasks %}
 - [{{ t['name'] }}](https://app.asana.com/0/1202469740885594/{{ t['gid'] }}){% endfor %}
+
 Remember to check out the [Shop & Maintenance Tasks project](https://app.asana.com/0/1202469740885594/1204138662113052) while you're on duty and see if you can help anything along. {{closing}}{% endif %}


### PR DESCRIPTION
The cache is updated every ~24h; this means that on-the-spot memberships fail on initial sign-in as the cache likely hasn't been updated. 

New cache behavior considers a non-`Active` account current membership status (or a missing account entirely) as a "miss", and attempts to fetch the account directly from Neon in case the state of the account has changed. 