### PR TITLE
Actually use the cache

### DIFF
--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -560,8 +560,14 @@ class AccountCache(WarmDict):
         self.by_booked_id = {}  # 1:1 mapping of user IDs in booked to users in Neon
         self.fuzzy = {}
 
+    def _value_has_active_membership(self, v):
+        for a in v.values():
+            if a.get("Account Current Membership Status") == "Active":
+                return True
+        return False
+
     def _handle_inactive_or_notfound(self, k, v):
-        if not v or v.get("Account Current Membership Status") != "Active":
+        if not v or not self._value_has_active_membership(v):
             aa = list(search_member(k, fields=self.FIELDS))
             if len(aa) > 0:
                 log.info(f"search_member cache miss returned results: {aa}")

--- a/protohaven_api/integrations/neon_test.py
+++ b/protohaven_api/integrations/neon_test.py
@@ -188,6 +188,26 @@ def test_account_cache_miss_inactive(mocker):
     assert c["asdf"] == {123: want1}
 
 
+def test_account_update_causes_cache_hit(mocker):
+    """Confirm that a call to update() fills the cache and does not require
+    a Neon lookup upon fetch"""
+    want = {
+        "Email 1": "asdf",
+        "First Name": "foo",
+        "Last Name": "bar",
+        "Account ID": 123,
+        "Account Current Membership Status": "Active",
+    }
+
+    mocker.patch.object(
+        n, "search_member", side_effect=AssertionError("should never be called")
+    )
+    c = n.AccountCache()
+    c.update(want)
+    assert c.get(want["Email 1"]) == {123: want}
+    assert c[want["Email 1"]] == {123: want}
+
+
 def test_account_cache_miss_keyerror(mocker):
     """Confirm that __getitem__ exceptions are suppressed if direct lookup
     succeeds, are thrown if direct lookup also fails"""


### PR DESCRIPTION
Logic for checking for an active membership was incorrect.