### PR TITLE
Clearance aware scheduling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,8 @@ repos:
     - id: pylint
       name: pylint
       entry: pylint
-      language: system
+      language: python
+      # language: system
       types: [python]
       args:
         [
@@ -30,7 +31,7 @@ repos:
           "-sn", # Don't display the score
           # integrations/tasks.py false positives
           "--generated-members=client.tasks,client.projects",
-          "--disable=logging-fstring-interpolation,import-error,too-many-positional-arguments",
+          "--disable=logging-fstring-interpolation,import-error",
         ]
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,6 @@ general:
   server_mode: ${PH_SERVER_MODE}
   behind_proxy: false
   cors: ${CORS}
-  unsafe_no_rbac: ${UNSAFE_NO_RBAC}
   session_secret: ${SESSION_SECRET}
   admin_users: ["1245"]
   precache_sign_in: ${PRECACHE_SIGN_IN}
@@ -12,6 +11,9 @@ general:
     ${EXTERNAL_ACCESS_CODES_AUTOMATION}: ["Automation"]
   class_scheduling:
     clearance_exclusion_range_days: 7
+  unsafe:
+    no_rbac: ${UNSAFE_NO_RBAC}
+    login_as_user: ${UNSAFE_LOGIN_AS}
 cronicle:
   # Used as a base for links to execution log when
   # CLI commands are issued via Cronicle

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,8 @@ general:
   precache_sign_in: ${PRECACHE_SIGN_IN}
   external_access_codes:
     ${EXTERNAL_ACCESS_CODES_AUTOMATION}: ["Automation"]
+  class_scheduling:
+    clearance_exclusion_range_days: 7
 cronicle:
   # Used as a base for links to execution log when
   # CLI commands are issued via Cronicle

--- a/protohaven_api/automation/classes/scheduler.py
+++ b/protohaven_api/automation/classes/scheduler.py
@@ -24,7 +24,8 @@ def fetch_formatted_availability(inst_filter, time_min, time_max):
     return tuples of times bounding their availability"""
     result = {}
     for inst in inst_filter:
-        rows = airtable.get_instructor_availability(inst)
+        inst_rec = airtable.get_instructor_record(inst)
+        rows = airtable.get_instructor_availability(inst_rec)
         # Have to drop the record IDs
         result[inst] = [
             [t0.isoformat(), t1.isoformat(), row_id]
@@ -162,7 +163,7 @@ def gen_class_and_area_stats(
             clearance_exclusion_window[0] <= end_date
             or clearance_exclusion_window[1] >= start_date
         ):
-            for clr in c["fields"]["Clearance (from Class)"]:
+            for clr in c["fields"].get("Clearance (from Class)") or []:
                 mapped = clearance_code_mapping.get(clr)
                 if mapped:
                     clearance_exclusion[mapped].append(clearance_exclusion_window)

--- a/protohaven_api/automation/classes/scheduler_test.py
+++ b/protohaven_api/automation/classes/scheduler_test.py
@@ -256,13 +256,15 @@ def test_gen_class_and_area_stats_exclusions(mocker):
 
 def test_fetch_formatted_availability(mocker):
     mocker.patch.object(
+        s.airtable, "get_instructor_record", return_value={"id": "asdf"}
+    )
+    mocker.patch.object(
         s.airtable,
         "get_instructor_availability",
         return_value=[
             {
                 "id": "rowid",
                 "fields": {
-                    "Instructor (from Instructor)": "foo",
                     "Start": d(0, 16).isoformat(),
                     "End": d(0, 19).isoformat(),
                     "Recurrence": "RRULE:FREQ=DAILY",

--- a/protohaven_api/automation/classes/scheduler_test.py
+++ b/protohaven_api/automation/classes/scheduler_test.py
@@ -54,7 +54,7 @@ def test_build_instructor_basic():
         days=1,
         hours=3,
         areas=["a0"],
-        exclusions=[[d(5), d(10), d(7)]],
+        exclusions=[[d(5), d(10), d(7), "class"]],
         score=1.0,
     )
     assert s.build_instructor(
@@ -174,34 +174,54 @@ def test_push_schedule(mocker):
     )
 
 
-def test_gen_class_and_area_stats_exclusions():
+def test_gen_class_and_area_stats_exclusions(mocker):
     """Verify that exclusions account for the time before and after a run of a class
     that should be avoided when schedling new classes"""
-    exclusions, _, _ = s.gen_class_and_area_stats(
+    mocker.patch.object(s, "get_config", return_value=7)
+    exclusions, _, clearance_exclusions, _ = s.gen_class_and_area_stats(
         [
             {
                 "fields": {
                     "Start Time": "2024-04-01",
                     "Class": ["r1"],
-                    "Days (from Class)": [0],
+                    "Clearance (from Class)": [12345],
+                    "Days (from Class)": [1],
+                    "Hours (from Class)": [3],
                     "Period (from Class)": [30],
+                    "Name (from Class)": "Class1",
+                    "Name (from Area) (from Class)": "Area1",
+                    "Instructor": "Foo",
                 }
             },
             {
                 "fields": {
                     "Start Time": "2024-03-01",
                     "Class": ["r1"],
-                    "Days (from Class)": [0],
+                    "Clearance (from Class)": [12345],
+                    "Days (from Class)": [
+                        2
+                    ],  # End of exclusion should be from last session
+                    "Hours (from Class)": [3],
                     "Period (from Class)": [30],
+                    "Name (from Class)": "Class1",
+                    "Name (from Area) (from Class)": "Area1",
+                    "Instructor": "Foo",
                 }
             },
         ],
         parse_date("2024-02-01T00:00:00-04:00"),
         parse_date("2024-05-01T00:00:00-05:00"),
+        {12345: "C1"},
     )
     assert [tuple([d.strftime("%Y-%m-%d") for d in dd]) for dd in exclusions["r1"]] == [
         ("2024-03-02", "2024-05-01", "2024-04-01"),
-        ("2024-01-31", "2024-03-31", "2024-03-01"),
+        ("2024-01-31", "2024-04-07", "2024-03-01"),
+    ]
+    assert [
+        tuple([d.strftime("%Y-%m-%d") for d in dd]) for dd in clearance_exclusions["C1"]
+    ] == [
+        ("2024-03-25", "2024-04-08", "2024-04-01"),
+        ("2024-02-23", "2024-03-08", "2024-03-01"),
     ]
 
 
@@ -243,6 +263,7 @@ def test_load_schedulable_classes(mocker):
                     "Hours": 5,
                     "Days": 2,
                     "Area": ["Area 1"],
+                    "Clearance": ["C1", "C2"],
                     "Image Link": "http://example.com/image1",
                 },
             },
@@ -269,11 +290,17 @@ def test_load_schedulable_classes(mocker):
     )
     mocker.patch.object(s, "compute_score", return_value=10)
 
-    classes, notices = s.load_schedulable_classes({})
+    classes, notices = s.load_schedulable_classes(
+        {"class1": [[d(0), d(2), d(1)]]}, {"C1": [[d(0), d(2), d(1)]]}
+    )
 
     assert len(classes) == 2
     assert classes[0].name == "Class One"
     assert classes[1].name == "Class Three"
+    assert classes[0].exclusions == [
+        [d(0), d(2), d(1), "class"],
+        [d(0), d(2), d(1), "clearance (C1)"],
+    ]
     assert "missing required fields" in notices["class2"][0]
     assert "Class is missing a promo image" in notices["class3"][0]
 
@@ -310,7 +337,14 @@ def test_generate_env(mocker):
         ],
     )
     mocker.patch.object(
-        s, "gen_class_and_area_stats", return_value=(set(), {}, {"instructor1": []})
+        s.airtable,
+        "get_all_records",
+        return_value=[
+            {"id": "rec1", "fields": {"Code": "Code1"}},
+        ],
+    )
+    mocker.patch.object(
+        s, "gen_class_and_area_stats", return_value=(set(), {}, {}, {"instructor1": []})
     )
     mocker.patch.object(
         s,

--- a/protohaven_api/automation/classes/solver.py
+++ b/protohaven_api/automation/classes/solver.py
@@ -29,6 +29,8 @@ class Class:
         assert isinstance(areas, list)
         self.areas = areas
 
+        # NOTE: exclusions are not factored at solver time; they are instead
+        # applied to instructor `candidates` scheduling times via `scheduler.py.`
         if len(exclusions) > 0 and isinstance(exclusions[0][0], str):
             # Convert from string to Date if required
             self.exclusions = [

--- a/protohaven_api/automation/classes/solver.py
+++ b/protohaven_api/automation/classes/solver.py
@@ -31,7 +31,9 @@ class Class:
 
         if len(exclusions) > 0 and isinstance(exclusions[0][0], str):
             # Convert from string to Date if required
-            self.exclusions = [[dateparser.parse(e) for e in ee] for ee in exclusions]
+            self.exclusions = [
+                [*[dateparser.parse(e) for e in ee[:-1]], ee[-1]] for ee in exclusions
+            ]
         else:
             self.exclusions = exclusions
         # Score is a normalized expected value based on revenue, likelihood to fill,

--- a/protohaven_api/automation/classes/validation.py
+++ b/protohaven_api/automation/classes/validation.py
@@ -47,9 +47,9 @@ def has_area_conflict(area_occupancy, t_start, t_end):
 def date_within_exclusions(d, exclusions):
     """Returns the matching exclusion date if `d` is
     within any of the tuples in the list of `exclusions`"""
-    for e1, e2, esched in exclusions:
+    for e1, e2, esched, eattr in exclusions:
         if e1 <= d <= e2:
-            return [e1, e2, esched]
+            return [e1, e2, esched, eattr]
     return False
 
 
@@ -104,10 +104,10 @@ def validate_candidate_class_time(  # pylint: disable=too-many-return-statements
         # Skip this particular time if it's in an exclusion region
         excluding_class_dates = date_within_exclusions(t0, c.exclusions)
         if excluding_class_dates:
-            e1, e2, esched = excluding_class_dates
+            e1, e2, esched, eattr = excluding_class_dates
             return (
                 False,
-                f"Too soon before/after same class (scheduled for "
+                f"Too soon before/after same {eattr} (scheduled for "
                 f"{esched.strftime('%Y-%m-%d')}; no repeats allowed "
                 f"between {e1.strftime('%Y-%m-%d')} and {e2.strftime('%Y-%m-%d')})",
             )

--- a/protohaven_api/automation/classes/validation_test.py
+++ b/protohaven_api/automation/classes/validation_test.py
@@ -106,7 +106,7 @@ def test_validate_candidate_class_time(tc):
         hours=tc.class_hours,
         days=tc.class_days,
         areas=["a0"],
-        exclusions=[[d(5), d(10), d(7)]],
+        exclusions=[[d(5), d(10), d(7), "class"]],
         score=1.0,
     )
     valid, reason = v.validate_candidate_class_time(
@@ -146,9 +146,14 @@ Tc = namedtuple("TC", "desc,d,exclusions,want")
 @pytest.mark.parametrize(
     "tc",
     [
-        Tc("Simple containment", d(0, 12), [(d(0), d(1), "foo")], [d(0), d(1), "foo"]),
-        Tc("Too late", d(2), [(d(0), d(1), "foo")], False),
-        Tc("Too early", d(-1), [(d(0), d(1), "foo")], False),
+        Tc(
+            "Simple containment",
+            d(0, 12),
+            [(d(0), d(1), "foo", "bar")],
+            [d(0), d(1), "foo", "bar"],
+        ),
+        Tc("Too late", d(2), [(d(0), d(1), "foo", "bar")], False),
+        Tc("Too early", d(-1), [(d(0), d(1), "foo", "bar")], False),
     ],
     ids=idfn,
 )

--- a/protohaven_api/commands/development.py
+++ b/protohaven_api/commands/development.py
@@ -324,9 +324,7 @@ class Commands:  # pylint: disable=too-few-public-methods
                     "Instructor": (lambda _: [random_id()]),
                     "Start": None,
                     "End": None,
-                    "Instructor (from Instructor)": random_name,
                     "Summary": lambda _: "A summary",
-                    "Email (from Instructor)": random_email,
                     "Recurrence": None,
                 },
                 "discounts": {

--- a/protohaven_api/handlers/auth.py
+++ b/protohaven_api/handlers/auth.py
@@ -58,15 +58,20 @@ def logout():
     return "You've been logged out"
 
 
+def login_with_neon_id(neon_id):
+    """Sets the session based on a Neon user ID"""
+    session["neon_id"] = neon_id
+    session["neon_account"], _ = neon_base.fetch_account(
+        session["neon_id"], required=True
+    )
+
+
 @page.route("/oauth_redirect")
 def neon_oauth_redirect():
     """Redirect back to the page the user came from for login"""
     code = request.args.get("code")
     rep = oauth.retrieve_token(_redirect_uri(), code)
-    session["neon_id"] = rep.get("access_token")
-    session["neon_account"], _ = neon_base.fetch_account(
-        session["neon_id"], required=True
-    )
+    login_with_neon_id(rep.get("access_token"))
     referrer = session.get("login_referrer", "/")
     log.info(f"Login referrer redirect: {referrer}")
     return redirect(referrer)

--- a/protohaven_api/handlers/index.py
+++ b/protohaven_api/handlers/index.py
@@ -15,7 +15,6 @@ from protohaven_api.handlers.auth import user_email, user_fullname
 from protohaven_api.integrations import airtable, mqtt, neon
 from protohaven_api.integrations.booked import get_reservations
 from protohaven_api.integrations.schedule import fetch_shop_events
-from protohaven_api.rbac import is_enabled as rbac_enabled
 from protohaven_api.rbac import require_login
 
 page = Blueprint("index", __name__, template_folder="templates")
@@ -33,14 +32,6 @@ def index():
 @page.route("/whoami")
 def whoami():
     """Returns data about the logged in user"""
-    if not rbac_enabled():
-        return {
-            "fullname": "Test User (RBAC disabled)",
-            "email": "noreply@noreply.com",
-            "clearances": [],
-            "roles": [],
-            "neon_id": "00000",
-        }
     neon_account = session.get("neon_account")
     if not neon_account:
         return Response("You are not logged in", status=400)

--- a/protohaven_api/handlers/instructor.py
+++ b/protohaven_api/handlers/instructor.py
@@ -448,8 +448,8 @@ def inst_availability():
                 status=400,
             )
         t1 += datetime.timedelta(hours=24)  # End date is inclusive
-        avail = list(airtable.get_instructor_availability(inst))
-
+        inst_rec = airtable.get_instructor_record(inst)
+        avail = list(airtable.get_instructor_availability(inst_rec))
         expanded = list(airtable.expand_instructor_availability(avail, t0, t1))
 
         log.info(f"Expanded and merged availability: {expanded}")

--- a/protohaven_api/integrations/airtable.py
+++ b/protohaven_api/integrations/airtable.py
@@ -409,14 +409,19 @@ def _day_trunc(d):
     return d.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
-def get_instructor_availability(inst):
+def get_instructor_record(inst_name):
+    """Fetches the instructor metadata by name"""
+    inst_name = inst_name.lower().strip()
+    for row in get_all_records("class_automation", "capabilities"):
+        if inst_name == row["fields"]["Instructor"].lower().strip():
+            return row["id"]
+    raise RuntimeError(f"Instructor ID missing for {inst_name}")
+
+
+def get_instructor_availability(inst_rec):
     """Fetches all rows from Availability airtable matching `inst` as instructor"""
-    inst = inst.strip().lower()
     for row in get_all_records("class_automation", "availability"):
-        row_inst = (
-            row["fields"].get("Instructor (from Instructor)", [""])[0].strip().lower()
-        )
-        if row_inst == inst:
+        if inst_rec in row["fields"].get("Instructor"):
             yield row
 
 

--- a/protohaven_api/integrations/airtable_test.py
+++ b/protohaven_api/integrations/airtable_test.py
@@ -29,7 +29,6 @@ def _arec(email, start, end, rrule=""):
         "id": 123,
         "fields": {
             "Instructor": [123],
-            "Email (from Instructor)": email,
             "Start": start.isoformat(),
             "End": end.isoformat(),
             "Recurrence": rrule,

--- a/protohaven_api/integrations/data/dev_airtable.py
+++ b/protohaven_api/integrations/data/dev_airtable.py
@@ -44,7 +44,7 @@ def recordless_op(base, tbl):
             rep.append(rec)
         log.info(f"Airtable add records: {rep}")
         check = mock_data()["airtable"][_base_lookup(base)][_tbl_lookup(tbl)]
-        log.info(f"In table: {check[-1]}")
+        log.info(f"Value in table: {check[-1]}")
         return {"records": rep}
     return Response("Method not supported", status=400)
 

--- a/protohaven_api/integrations/data/dev_neon.py
+++ b/protohaven_api/integrations/data/dev_neon.py
@@ -188,7 +188,7 @@ def search_accounts():
 @app.route("/v2/accounts/<account_id>", methods=["GET", "PATCH"])
 def get_account(account_id):
     """Mock account lookup endpoint for Neon"""
-    a = mock_data()["neon"]["accounts"].get(int(account_id))
+    a = mock_data()["neon"]["accounts"].get(account_id)
     if not a:
         return Response("Account not found", status=404)
 
@@ -200,7 +200,7 @@ def get_account(account_id):
 @app.route("/v2/accounts/<account_id>/memberships")
 def get_account_memberships(account_id):
     """Mock account membership endpoint for Neon"""
-    m = mock_data()["neon"]["memberships"].get(int(account_id))
+    m = mock_data()["neon"]["memberships"].get(account_id)
     if not m:
         return Response("Memberships not found for account", status=404)
     return {

--- a/protohaven_api/main.py
+++ b/protohaven_api/main.py
@@ -25,7 +25,7 @@ app = configure_app(
     session_secret=get_config("general/session_secret"),
 )
 
-if get_config("general/unsafe_no_rbac", as_bool=True):
+if get_config("general/unsafe/no_rbac", as_bool=True):
     log.warning(
         "DANGER DANGER DANGER\n\nRBAC DISABLED; EVERYONE CAN DO EVERYTHING\n\nDANGER DANGER DANGER"
     )

--- a/svelte/src/lib/techs/techs_list.svelte
+++ b/svelte/src/lib/techs/techs_list.svelte
@@ -82,7 +82,6 @@ function clearance_click(id) {
 {#await promise}
 <Spinner/>
 {:then p}
-  {#if p.tech_lead }
   <div class="d-flex">
     {#if enrolling}
       <Spinner/>
@@ -97,11 +96,12 @@ function clearance_click(id) {
             <DropdownItem on:click={() => sort_type="name" }>By Name</DropdownItem>
         </DropdownMenu>
     </Dropdown>
-    <Input class="mx-1" text bind:value={new_tech_email} disabled={enrolling} placeholder="email address"/>
-    <Button class="mx-1" on:click={()=>set_enrollment(true)} disabled={enrolling}>Enroll</Button>
-    <Button class="mx-1" on:click={()=>set_enrollment(false)} disabled={enrolling}>Disenroll</Button>
+    {#if p.tech_lead }
+      <Input class="mx-1" text bind:value={new_tech_email} disabled={enrolling} placeholder="email address"/>
+      <Button class="mx-1" on:click={()=>set_enrollment(true)} disabled={enrolling}>Enroll</Button>
+      <Button class="mx-1" on:click={()=>set_enrollment(false)} disabled={enrolling}>Disenroll</Button>
+    {/if}
   </div>
-  {/if}
   <Toast class="me-1" style="position:fixed; bottom: 2vh; right: 2vh;" autohide isOpen={toast_msg} on:close={() => (toast_msg = null)}>
     <ToastHeader icon={toast_msg.color}>{toast_msg.title}</ToastHeader>
     <ToastBody>{toast_msg.msg}</ToastBody>

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -18,6 +18,7 @@ const PROXY_PATHS = [
   '^/staff/.',
   '^/events/.',
   '^/instructor/.',
+  '^/admin/.',
   '/whoami',
   '/neon_lookup',
   '/class_listing',


### PR DESCRIPTION
#249

* Creates blanket exclusion windows for classes based on similarity of clearances offered, and allows qualifying different time exclusion windows as "class" or "clearance" caused, so the instructor knows what's going on. 
* Includes some tweaks to pre-commit to properly work in the new nix-flake world.
* Also modifies the exclusion window for multi-week classes to X days before the first session and X days past the last session - previously X days before/after the first session.
* Unit tested exclusions in the scheduler