### PR TITLE
Properly renew shop tech lead roles' memberships

### DIFF
--- a/protohaven_api/commands/finances.py
+++ b/protohaven_api/commands/finances.py
@@ -472,7 +472,7 @@ class Commands:
                 "new_end": "N/A",
                 "membership_type": role["name"],
             }
-            log.info(f"Processing tech {t}")
+            log.info(f"Processing {role['name']} {t}")
             end = self._last_expiring_membership(t["Account ID"])
             if end is None:
                 s["end_date"] = "ERR INFINITE"
@@ -539,6 +539,15 @@ class Commands:
         """If a volunteer's membership is due to expire soon, create a
         future membership that starts when the previous one ends."""
         summary = []
+        log.info("Refreshing shop tech lead memberships...")
+        self._refresh_role_memberships(
+            args,
+            summary,
+            Role.SHOP_TECH_LEAD,
+            level={"id": 19, "name": "Shop Tech"},
+            term={"id": 61, "name": "Shop Tech"},
+        )
+        log.info("Refreshing shop tech memberships...")
         self._refresh_role_memberships(
             args,
             summary,
@@ -546,6 +555,7 @@ class Commands:
             level={"id": 19, "name": "Shop Tech"},
             term={"id": 61, "name": "Shop Tech"},
         )
+        log.info("Refreshing software dev memberships...")
         self._refresh_role_memberships(
             args,
             summary,

--- a/protohaven_api/commands/finances_test.py
+++ b/protohaven_api/commands/finances_test.py
@@ -354,12 +354,26 @@ def test_refresh_volunteer_memberships(mocker, cli):
                     "Membership End Date": d(0, 23).strftime("%Y-%m-%d"),
                 }
             ],
+            [
+                {
+                    "Account ID": 789,
+                    "First Name": "Jorb",
+                    "Last Name": "Dorb",
+                    "Membership End Date": d(0, 23).strftime("%Y-%m-%d"),
+                },
+                {
+                    "Account ID": 999,
+                    "First Name": "Past",
+                    "Last Name": "DeLimit",
+                    "Membership End Date": d(0, 23).strftime("%Y-%m-%d"),
+                },
+            ],
         ],
     )
     mocker.patch.object(f.Commands, "_last_expiring_membership", return_value=d(0, 23))
     mocker.patch.object(f.neon, "create_zero_cost_membership", return_value={"id": 456})
 
-    got = cli("refresh_volunteer_memberships", ["--apply", "--limit", "2"])
+    got = cli("refresh_volunteer_memberships", ["--apply", "--limit", "3"])
     assert len(got) == 1
     assert got[0]["target"] == "#membership-automation"
     assert got[0]["body"] == MatchStr("new Shop Tech membership")
@@ -375,6 +389,13 @@ def test_refresh_volunteer_memberships(mocker, cli):
             ),
             mocker.call(
                 456,
+                d(1, 23),
+                d(31, 23),
+                level={"id": mocker.ANY, "name": "Shop Tech"},
+                term={"id": mocker.ANY, "name": "Shop Tech"},
+            ),
+            mocker.call(
+                789,
                 d(1, 23),
                 d(31, 23),
                 level={"id": mocker.ANY, "name": "Software Developer"},


### PR DESCRIPTION
Previously, shop tech leads had to also have the "shop tech" role. But this makes them show up on e.g. the Roster tab of /techs as a tech without a shift. 

This change processes membership renewals for them, removing the need to include the "Shop Tech" role.