### PR TITLE
Bookstack: add auto-generated links to tool tutorials & clearances

### DIFF
--- a/bookstack/theme/functions.php
+++ b/bookstack/theme/functions.php
@@ -27,4 +27,5 @@ require_once("approvals.php");
 require_once("approvals_test.php");
 require_once("backups.php");
 require_once("tool_maintenance_history.php");
+require_once("tool_links.php");
 ?>

--- a/bookstack/theme/tool_links.php
+++ b/bookstack/theme/tool_links.php
@@ -1,0 +1,54 @@
+<?php
+use BookStack\Entities\Queries\PageQueries;
+use BookStack\Entities\Models\Book;
+use BookStack\Entities\Models\Page;
+use BookStack\Theming\ThemeEvents;
+use BookStack\Facades\Theme;
+use Illuminate\Routing\Router;
+use BookStack\Users\Models\Role;
+use BookStack\Activity\Models\Tag;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Http\Request;
+
+
+function getPageURLsWithToolCode($tool_code) {
+  $CLEARANCE_BOOKS = ["basic-maintenance"];
+  $TOOL_TUTORIAL_BOOKS = ["test"];
+  $tags = Tag::where('name', 'tool_code')
+    ->where('value', $tool_code)
+    ->with('entity')
+    ->with('entity.book')
+    ->get();
+  $result = array();
+  foreach ($tags as $tag) {
+    // Log::info($tag);
+    $page = $tag->entity ?? null;
+    $book_slug = $page['book']['slug'];
+    if ($page instanceof \BookStack\Entities\Models\Page) {
+      if (in_array($book_slug, $CLEARANCE_BOOKS)) {
+        $result["clearance"] = $page->getUrl();
+      } elseif (in_array($book_slug, $TOOL_TUTORIAL_BOOKS)) {
+        $result["tool_tutorial"] = $page->getUrl();
+      }
+    }
+  }
+  return $result;
+}
+
+
+Theme::listen(ThemeEvents::ROUTES_REGISTER_WEB, function (Router $router) {
+
+  $router->get('/tool_clearance/{tool_code}', function ($tool_code) {
+    $NOTFOUND_URL = "/book/test/page/herp";
+    $urls = getPageURLsWithToolCode($tool_code);
+    return redirect($urls['clearance'] ?? $NOTFOUND_URL);
+  });
+
+  $router->get('/tool_tutorial/{tool_code}', function ($tool_code) {
+    $NOTFOUND_URL = "/book/test/page/herp";
+    $urls = getPageURLsWithToolCode($tool_code);
+    return redirect($urls['tool_tutorial'] ?? $NOTFOUND_URL);
+  });
+});
+
+?>

--- a/bookstack/theme/tool_links.php
+++ b/bookstack/theme/tool_links.php
@@ -39,13 +39,13 @@ function getPageURLsWithToolCode($tool_code) {
 Theme::listen(ThemeEvents::ROUTES_REGISTER_WEB, function (Router $router) {
 
   $router->get('/tool_clearance/{tool_code}', function ($tool_code) {
-    $NOTFOUND_URL = "/book/test/page/herp";
+    $NOTFOUND_URL = "/books/clearances/page/missing-clearance-page";
     $urls = getPageURLsWithToolCode($tool_code);
     return redirect($urls['clearance'] ?? $NOTFOUND_URL);
   });
 
   $router->get('/tool_tutorial/{tool_code}', function ($tool_code) {
-    $NOTFOUND_URL = "/book/test/page/herp";
+    $NOTFOUND_URL = "/books/tool-guides/page/tool-guide-missing";
     $urls = getPageURLsWithToolCode($tool_code);
     return redirect($urls['tool_tutorial'] ?? $NOTFOUND_URL);
   });


### PR DESCRIPTION
Should eliminate the maintenance requirement of ~200 or so links to documentation in Airtable.