### PR TITLE
Properly initialize volunteer memberships for newly created accounts

### DIFF
--- a/protohaven_api/commands/finances.py
+++ b/protohaven_api/commands/finances.py
@@ -468,16 +468,15 @@ class Commands:
                 "fname": t["First Name"].strip(),
                 "lname": t["Last Name"].strip(),
                 "account_id": t["Account ID"],
-                "membership_id": "DRYRUN",
+                "membership_id": "Not created",
                 "new_end": "N/A",
                 "membership_type": role["name"],
             }
             log.info(f"Processing {role['name']} {t}")
             end = self._last_expiring_membership(t["Account ID"])
             if end is None:
-                s["end_date"] = "ERR INFINITE"
-                summary.append(s)
-                continue
+                s["end_date"] = "N/A"
+                end = tznow()
 
             if now + datetime.timedelta(days=args.expiry_threshold) < end:
                 continue  # Skip if active membership not expiring soon


### PR DESCRIPTION
Had an edge case with the "shop tech" user where it's never had a membership, but the membership refresh automation thought it might need one. The automation bailed out when the "age of most recent membership" was set to `None`. 

This change allows creating the volunteer membership even if an account has never had a membership before - so long as the proper `API Server Role` is set for that account. 