### PR TITLE
Fix loophole on event backfill, dev support for neon attendees/tickets

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -129,6 +129,7 @@ nocodb:
       memberships: "mv3lhkooul6is39"
       events: "mjxxyvyn5a8qegm"
       attendees: "meoi8fng058o3rb"
+      tickets: "mx3ak3a6hdre0c9"
       clearance_codes: "mmk3g8k9pwcykd0"
     fake_wyze:
       devices: "mhjg19llr23inaa"

--- a/protohaven_api/handlers/admin.py
+++ b/protohaven_api/handlers/admin.py
@@ -10,7 +10,12 @@ from protohaven_api.automation.membership import membership as memauto
 from protohaven_api.config import get_config
 from protohaven_api.handlers.auth import login_with_neon_id
 from protohaven_api.integrations import airtable, comms, mqtt, neon, neon_base, tasks
-from protohaven_api.rbac import Role, require_login_role, roles_from_api_key
+from protohaven_api.rbac import (
+    Role,
+    require_dev_environment,
+    require_login_role,
+    roles_from_api_key,
+)
 
 page = Blueprint("admin", __name__, template_folder="templates")
 
@@ -18,7 +23,7 @@ log = logging.getLogger("handlers.admin")
 
 
 @page.route("/admin/login_as", methods=["GET"])
-@require_login_role(Role.ADMIN)
+@require_dev_environment()
 def login_as_user():
     """Force the browser session to a specific user (for dev)"""
     neon_id = int(request.values["neon_id"])

--- a/protohaven_api/handlers/techs.py
+++ b/protohaven_api/handlers/techs.py
@@ -375,9 +375,11 @@ def techs_backfill_events():
                 }
             )
 
-    tech_lead = am_role(Role.SHOP_TECH_LEAD)
-
-    return {"events": for_techs, "tech_lead": tech_lead}
+    return {
+        "events": for_techs,
+        "can_register": am_role(Role.SHOP_TECH) or am_role(Role.SHOP_TECH_LEAD),
+        "tech_lead": am_role(Role.SHOP_TECH_LEAD),
+    }
 
 
 def _notify_registration(account_id, event_id, action):

--- a/protohaven_api/integrations/data/dev_neon.py
+++ b/protohaven_api/integrations/data/dev_neon.py
@@ -196,7 +196,12 @@ def get_events():
 @app.route("/v2/events/<event_id>/tickets")
 def get_event_tickets(event_id):
     """Mock event tickets endpoint for Neon"""
-    raise NotImplementedError("TODO")
+    for row in airtable_base.get_all_records("fake_neon", "tickets"):
+        if str(row["fields"]["eventId"]) == str(event_id):
+            # Weird that Neon doesn't paginate these results, but a lot of their
+            # API is inconsistent with itself, so ¯\_(ツ)_/¯
+            return row["fields"]["data"]
+    return []
 
 
 @app.route("/v2/events/<event_id>/eventRegistrations")
@@ -211,7 +216,7 @@ def get_attendees(event_id):
     result = []
     for row in airtable_base.get_all_records("fake_neon", "attendees"):
         if str(row["fields"]["eventId"]) == str(event_id):
-            result.append(row["fields"]["data"])
+            result += row["fields"]["data"]
             break
     return {
         "attendees": result,

--- a/protohaven_api/rbac.py
+++ b/protohaven_api/rbac.py
@@ -121,6 +121,21 @@ def get_roles():
     return result
 
 
+def require_dev_environment():
+    """Require the server to be running a non-prod (i.e. Dev) environment"""
+
+    def fn_setup(fn):
+        def do_dev_check(*args, **kwargs):
+            if get_config("general/server_mode").lower() == "prod":
+                return Response("Access Denied", status=401)
+            return fn(*args, **kwargs)
+
+        do_dev_check.__name__ = fn.__name__
+        return do_dev_check
+
+    return fn_setup
+
+
 def require_login_role(*role, redirect_to_login=True):
     """Decorator that requires the use to be logged in and have a particular role"""
 

--- a/svelte/src/lib/techs/events.svelte
+++ b/svelte/src/lib/techs/events.svelte
@@ -82,11 +82,6 @@ function delete_event(eid) {
 <CardBody>
     <p>Note: you will need to pay the cost of materials when you show up.</p>
     <p>You can pay at the front desk via Square - select "Walk-In (3 Hr Class / add price)", set to the cost listed above, charge as normal.</p>
-    {#if !user }
-      <p><strong>You must <a href="http://api.protohaven.org/login">login</a> to register.</strong></p>
-    {:else}
-      <p>Click Register on events below to register as <br/><strong>{user.fullname}</strong> ({user.email})</p>
-    {/if}
     {#await promise}
       <Spinner/>loading...
     {:then p}
@@ -99,17 +94,21 @@ function delete_event(eid) {
     {:catch error}
     <FetchError {error}/>
     {/await}
-    <ListGroup>
     {#if p.length === 0}
       <em>No event available for backfill - please check back later.</em>
+    {:else if !user || !p.can_register}
+      <p><strong>You must <a href="http://api.protohaven.org/login">login</a> as a Shop Tech or Tech Lead to register for events.</strong></p>
+    {:else}
+      <p>Click Register on events below to register as <br/><strong>{user.fullname}</strong> ({user.email})</p>
     {/if}
+    <ListGroup>
     {#each p.events as r}
       <ListGroupItem>
             <div><strong>{r.name}</strong></div>
             <div>On {new Date(r.start).toLocaleString()}</div>
             <div><a href={`https://protohaven.org/e/${r.id}`} target="_blank">Event Details</a></div>
             <div>{r.capacity - r.attendees.length} seat(s) left</div>
-            {#if user}
+            {#if user && p.can_register}
             <div>
             {#if r.attendees.indexOf(user.neon_id) !== -1}
               <strong>You are registered!</strong>


### PR DESCRIPTION
Previously, all it took was anyone logged into neon to register for backfill events - this change restricts it to techs and leads.

Also added support for looking up attendees and ticketing for Neon events in the dev environment.