### PR TITLE
Fix tech dash in dev, properly handle dates for member check

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -124,12 +120,6 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "dump.sql"
-      ]
     }
   ],
   "results": {
@@ -142,13 +132,13 @@
         "line_number": 3
       }
     ],
-    "nocodb/docker-compose.yml": [
+    "nocodb/dump.sql": [
       {
         "type": "Secret Keyword",
-        "filename": "nocodb/docker-compose.yml",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "filename": "nocodb/dump.sql",
+        "hashed_secret": "0f6f7f72b2b2c20be72cbeff65450977114eadf5",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 12080
       }
     ],
     "svelte/pnpm-lock.yaml": [
@@ -32082,5 +32072,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-07T12:01:49Z"
+  "generated_at": "2025-07-04T18:39:11Z"
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,7 +18,7 @@ services:
       - source: ph-config
         target: /config.yaml
     depends_on:
-      nocodb:
+      nocodb_frontend:
         condition: service_healthy
     develop:
       watch:
@@ -73,7 +73,7 @@ services:
       test: "curl localhost:5173"
       timeout: 2s
 
-  nocodb:
+  nocodb_frontend:
     image: "nocodb/nocodb:latest"
     container_name: nocodb_frontend
     volumes:

--- a/protohaven_api/handlers/techs.py
+++ b/protohaven_api/handlers/techs.py
@@ -114,11 +114,25 @@ def techs_members():
     """Fetches today's sign-in information for members"""
     start = request.values.get("start")
     start = (dateparser.parse(start) if start else tznow()).replace(
-        hour=0, minute=0, second=0
+        hour=0, minute=0, second=0, tzinfo=tz
     )
     end = start.replace(hour=23, minute=59, second=59)
     log.info(f"Fetching signins from {start} to {end}")
-    return list(airtable.get_signins_between(start, end))
+    return [
+        {
+            k: getattr(s, k)
+            for k in (
+                "name",
+                "status",
+                "email",
+                "member",
+                "clearances",
+                "violations",
+                "created",
+            )
+        }
+        for s in airtable.get_signins_between(start, end)
+    ]
 
 
 @page.route("/techs/area_leads")

--- a/protohaven_api/integrations/data/dev_neon.py
+++ b/protohaven_api/integrations/data/dev_neon.py
@@ -46,6 +46,7 @@ def _neon_dev_outputify(rec, field):
         "Account ID": lambda a: a["accountId"],
         "First Name": lambda a: a["primaryContact"]["firstName"],
         "Last Name": lambda a: a["primaryContact"]["lastName"],
+        "Preferred Name": lambda a: a["primaryContact"].get("preferredName"),
         "Household ID": lambda a: a.get("householdId"),
         "Company ID": lambda a: a.get("companyId"),
         "Email 1": lambda a: a["primaryContact"].get("email1"),

--- a/svelte/src/lib/techs/members.svelte
+++ b/svelte/src/lib/techs/members.svelte
@@ -19,24 +19,16 @@ function refresh() {
     loaded = true;
     let by_email = {};
     for (let d of data) {
-      const t = new Date(d['Created']);
+      d.created = new Date(d.created);
+      console.log(d);
       if (!by_email[d['Email']]) {
-        by_email[d['Email']] = {
-          "first_timestamp": t,
-          "timestamps": new Set(),
-          "member": d['Am Member'],
-          "email": d['Email'],
-          "clearances": (d['Clearances']) ? d['Clearances'].split(',').map(entry => entry.trim()) : [],
-          "status": d['Status'] || 'UNKNOWN',
-          "name": d['Full Name'] || null,
-          "violations": (d['Violations']) ? d['Violations'].split(',').map(entry => entry.trim()): [],
-        };
+        by_email[d['Email']] = {...d, "timestamps": new Set()};
       }
-      by_email[d['Email']]['timestamps'].add(t.toLocaleTimeString());
+      by_email[d['Email']]['timestamps'].add(d.created.toLocaleTimeString());
     }
     let results = Object.values(by_email);
     // Sort descending, newest on top
-    results.sort((a, b) => b.first_timestamp - a.first_timestamp);
+    results.sort((a, b) => b.created - a.created);
     return results;
   });
 }
@@ -67,7 +59,7 @@ $: {
     {#each p as r}
       <ListGroupItem>
         <p><strong>{r.email}{#if r.name}&nbsp;({r.name}){/if}</strong>
-          {r.first_timestamp.toLocaleTimeString()} -
+          {r.created.toLocaleTimeString()} -
               {#if !r.member}
                 Guest
               {:else}


### PR DESCRIPTION
Closes #374 - I'd failed to apply the tzinfo to the date when passing it to airtable to fetch a specific date range of sign-ins.

This change also creates a dataclass "view" called SignInEvent that handles parsing results from Airtable.

I also threw in `start_utc` and `end_utc` on the `Event` dataclass for good measure as a start to #375. 

When working on these bugs I noticed requests in the dev environment were also failing for the `/techs/list` handler due to missing data in Nocodb. Added a bit more safe handling of none-types to address that.