### PR TITLE
Respect holidays in shift forecast

### DIFF
--- a/protohaven_api/automation/techs/techs.py
+++ b/protohaven_api/automation/techs/techs.py
@@ -1,11 +1,20 @@
 """Forecasting methods for shop tech shift staffing"""
 import datetime
+import logging
 from collections import defaultdict
 
+import holidays
+
 from protohaven_api.integrations import airtable, neon
+from protohaven_api.integrations.models import Member
 from protohaven_api.rbac import Role
 
 DEFAULT_FORECAST_LEN = 16
+
+log = logging.getLogger("protohaven_api.automation.techs.techs")
+
+# Pylint seems to think `US()` doesn't exist. It may be dynamically loaded?
+us_holidays = holidays.US()  # pylint: disable=no-member
 
 
 def _calendar_badge_color(num_people):
@@ -19,11 +28,31 @@ def _calendar_badge_color(num_people):
     return "danger"
 
 
-def _create_calendar_view(
-    start_date, shift_map, forecast_len
+def resolve_overrides(overrides, shift):
+    """We must translate overrides into Member instances, with
+    special handling of "guest" techs if they do not exist in Neon"""
+    ovr_id, ovr_people, ovr_editor = overrides.get(shift) or (None, [], None)
+    for i, p in enumerate(ovr_people):
+        fname, lname = [n.strip() for n in p.split(" ")][:2]
+        mm = list(neon.search_members_by_name(fname, lname, also_fetch=True))
+        if len(mm) >= 1:
+            log.warning("Multiple member matches for Neon lookup of tech override {p}")
+            ovr_people[i] = mm[0]
+        else:
+            log.warning(
+                f"Tech override not found in neon: {p}. Creating name-only Member object"
+            )
+            ovr_people[i] = Member.from_neon_search(
+                {"First Name": fname, "Last Name": lname}
+            )
+    return ovr_id, ovr_people, ovr_editor
+
+
+def create_calendar_view(
+    start_date, shift_map, overrides, forecast_len
 ):  # pylint: disable=too-many-locals, too-many-nested-blocks
+    """Create a calendar view of tech shifts, respecting overrides and holidays"""
     calendar_view = []
-    overrides = dict(airtable.get_forecast_overrides())
     for i in range(forecast_len):
         d = start_date + datetime.timedelta(days=i)
         dstr = d.strftime("%Y-%m-%d")
@@ -31,19 +60,13 @@ def _create_calendar_view(
         for ap in ["AM", "PM"]:
             s = f"{d.strftime('%A')} {ap}"
 
-            ovr, ovr_people, ovr_editor = overrides.get(
-                f"{dstr} {ap}", (None, None, None)
+            ovr_id, ovr_people, ovr_editor = resolve_overrides(
+                overrides, f"{dstr} {ap}"
             )
-            for i, p in enumerate(ovr_people):
-                fname, lname = [n.strip() for n in p.split(" ")][:2]
-                mm = list(neon.search_members_by_name(fname, lname, also_fetch=True))
-                if len(mm) != 1:
-                    raise RuntimeError(
-                        "Multiple member matches for Neon lookup of tech override {p}"
-                    )
-                ovr_people[i] = mm[0]
 
-            people = shift_map.get(s, [])
+            # On holidays, we assume by default that nobody is on duty.
+            people = shift_map.get(s, []) if d not in us_holidays else []
+
             final_people = []
             for p in people:  # remove if outside of the tech's tenure
                 if (p.shop_tech_first_day is None or p.shop_tech_first_day <= d) and (
@@ -53,12 +76,16 @@ def _create_calendar_view(
 
             shift = {
                 "title": f"{d.strftime('%a %m/%d')} {ap}",
-                "people": ovr_people or final_people,
+                "people": ovr_people if ovr_id else final_people,
                 "id": f"Badge{i}{ap}",
             }
             shift["color"] = _calendar_badge_color(len(shift["people"]))
-            if ovr:
-                shift["ovr"] = {"id": ovr, "orig": final_people, "editor": ovr_editor}
+            if ovr_id:
+                shift["ovr"] = {
+                    "id": ovr_id,
+                    "orig": final_people,
+                    "editor": ovr_editor,
+                }
             day[ap] = shift
         calendar_view.append(day)
     return calendar_view
@@ -85,11 +112,12 @@ def generate(date, forecast_len, include_pii=False):
         ]
 
     date = date.replace(hour=0, minute=0, second=0, microsecond=0)
+    overrides = dict(airtable.get_forecast_overrides())
     techs = list(neon.search_members_with_role(Role.SHOP_TECH, tech_fields))
     shift_map = defaultdict(list)
     for t in techs:
         shift_map[t.shop_tech_shift].append(t)
 
     return {
-        "calendar_view": _create_calendar_view(date, shift_map, forecast_len),
+        "calendar_view": create_calendar_view(date, shift_map, overrides, forecast_len),
     }

--- a/protohaven_api/integrations/models.py
+++ b/protohaven_api/integrations/models.py
@@ -439,10 +439,12 @@ class Member:  # pylint:disable=too-many-public-methods
         """Returns the tuple of ("weekday", AM|PM) indicating the
         member's shop tech shift"""
         v = self._get_custom_field("Shop Tech Shift", "value")
-        if not isinstance(v, str) or "," not in v:
+        if not isinstance(v, str) or " " not in v:
             return (None, None)
-        v = [s.strip() for s in v.split(",")]
-        return v[0], v[1]
+        v = [s.strip() for s in v.split(" ") if s.strip() != ""]
+        if len(v) != 2:
+            return (None, None)
+        return v[0].title(), v[1].upper()
 
     @property
     def booked_id(self):

--- a/protohaven_api/integrations/models_test.py
+++ b/protohaven_api/integrations/models_test.py
@@ -49,6 +49,22 @@ def test_lname():
     assert m.lname == "Test"
 
 
+def test_shop_tech_shift_spelling_correction():
+    """Test Member.fname property"""
+    data = {
+        "individualAccount": {
+            "accountCustomFields": [
+                {
+                    "name": "Shop Tech Shift",
+                    "value": "  SuNdAy   am   ",
+                }
+            ]
+        }
+    }
+    m = Member(neon_raw_data=data)
+    assert m.shop_tech_shift == ("Sunday", "AM")
+
+
 Tc = namedtuple("TC", "desc,first,preferred,last,pronouns,want")
 
 


### PR DESCRIPTION
Part of #367 

Also fixes parsing of shifts in the `Member` class (space-delimited, fixes capital casing, accounts for leading/trailing whitespace)