### PR TITLE
Several small tweaks after cronicle QA

### DIFF
--- a/protohaven_api/automation/classes/builder_test.py
+++ b/protohaven_api/automation/classes/builder_test.py
@@ -29,7 +29,7 @@ def _upcoming_event(mocker):
         occupancy=1 / 6,
         in_blocklist=lambda: False,
         instructor_email="inst@ructor.com",
-        instructor_fname="Test",
+        instructor_name="Test",
         volunteer=True,
         supply="Supply Check Needed",
         supply_cost=5,

--- a/protohaven_api/automation/techs/techs.py
+++ b/protohaven_api/automation/techs/techs.py
@@ -37,7 +37,7 @@ def resolve_overrides(overrides, shift):
         fname, lname = [n.strip() for n in p.split(" ")][:2]
         mm = list(neon.search_members_by_name(fname, lname, also_fetch=True))
         if len(mm) >= 1:
-            log.warning("Multiple member matches for Neon lookup of tech override {p}")
+            log.warning(f"Multiple member matches for Neon lookup of tech override {p}")
             ovr_people[i] = mm[0]
         else:
             log.warning(

--- a/protohaven_api/commands/classes.py
+++ b/protohaven_api/commands/classes.py
@@ -508,6 +508,12 @@ class Commands:
                     if result_id:
                         log.error("Failed; reverting event creation")
                         log.info(neon_base.delete_event_unsafe(result_id))
+                        airtable.update_record(
+                            {"Neon ID": ""},
+                            "class_automation",
+                            "schedule",
+                            event["id"],
+                        )
                     try:
                         comms.send_discord_message(
                             f"Reverted class #{result_id}; creation failed: {e}\n"

--- a/protohaven_api/commands/classes_test.py
+++ b/protohaven_api/commands/classes_test.py
@@ -324,5 +324,7 @@ def test_post_classes_to_neon_reverts_on_failure(cli, mocker):
     )
     mock_schedule.assert_called_once()
     mock_pricing.assert_called_once()
-    mock_airtable.assert_not_called()
+    mock_airtable.assert_called_once_with(
+        {"Neon ID": ""}, "class_automation", "schedule", "test_id"
+    )
     mock_delete.assert_called_once_with("test_event_id")

--- a/protohaven_api/commands/forwarding.py
+++ b/protohaven_api/commands/forwarding.py
@@ -342,7 +342,7 @@ class Commands:
         techs_on_duty = forecast.generate(now, 1, include_pii=True)["calendar_view"][0]
         # Pick AM vs PM shift
         techs_on_duty = techs_on_duty["AM" if shift.endswith("AM") else "PM"]["people"]
-        log.info(f"Expecting on-duty techs: {techs_on_duty}")
+        log.info(f"Expecting on-duty techs: {[t.name for t in techs_on_duty]}")
         email_map = {t.email: t for t in techs_on_duty}
         on_duty_ok = False
         log.info("Sign ins:")

--- a/protohaven_api/commands/forwarding_test.py
+++ b/protohaven_api/commands/forwarding_test.py
@@ -59,6 +59,7 @@ def test_tech_sign_ins(mocker, tc, cli):
                             mocker.Mock(
                                 email="a@b.com",
                                 name="A B (they/them)",
+                                discord_user=None,
                                 shift=["Monday", "AM"],
                             )
                         ]
@@ -68,6 +69,7 @@ def test_tech_sign_ins(mocker, tc, cli):
                             mocker.Mock(
                                 email="c@d.com",
                                 name="C D (he/him)",
+                                discord_user=None,
                                 shift=["Monday", "PM"],
                             )
                         ]

--- a/protohaven_api/commands/maintenance.py
+++ b/protohaven_api/commands/maintenance.py
@@ -119,6 +119,7 @@ class Commands:
                     traceback.print_exc()
                     errs.append(e)
             else:
+                t["gid"] = "NO_APPLY"  # Appease the templater
                 scheduled.append(t)
 
             if len(scheduled) >= args.num:

--- a/protohaven_api/integrations/comms_test.py
+++ b/protohaven_api/integrations/comms_test.py
@@ -81,7 +81,7 @@ TEST_EVENT = {
     "neon_id": "34567",
     "start_date": d(0),
     "name": "Test Event",
-    "instructor_fname": "TestInstName",
+    "instructor_name": "TestInstName",
     "capacity": 6,
     "attendee_count": 3,
     "supply_cost": 0,
@@ -91,9 +91,9 @@ TEST_ATTENDEE = {
     "email": "test@attendee.com",
 }
 
-tech1 = MagicMock(email="a@a.com")
+tech1 = MagicMock(email="a@a.com", discord_user="foobar")
 tech1.name = "Tech A"
-tech2 = MagicMock(email="b@b.com")
+tech2 = MagicMock(email="b@b.com", discord_user=None)
 tech2.name = "Tech B"
 
 TESTED_TEMPLATES = [
@@ -423,7 +423,7 @@ HASHES = {
     "registrant_class_confirmed": "d6c0ac936f4c44dd",  # pragma: allowlist secret
     "registrant_post_class_survey": "7f89d4a2a4211f67",  # pragma: allowlist secret
     "schedule_push_notification": "fdb8409ccac4ba4b",  # pragma: allowlist secret
-    "shift_no_techs": "f74f25571d5a93b1",  # pragma: allowlist secret
+    "shift_no_techs": "28da9194d12b5db6",  # pragma: allowlist secret
     "shop_tech_applications": "a011ed984ed4a302",  # pragma: allowlist secret
     "square_validation_action_needed": "8cf97c894e5171aa",  # pragma: allowlist secret
     "tech_daily_tasks": "950fc9858cdf56bd",  # pragma: allowlist secret

--- a/protohaven_api/integrations/templates/instructor_check_supplies.jinja2
+++ b/protohaven_api/integrations/templates/instructor_check_supplies.jinja2
@@ -1,5 +1,5 @@
 {% set evt_date = evt.start_date.strftime("%B %-d") %}
-{% if subject %}{{evt.name}} on {{evt_date}} - please confirm class supplies{% else %}Hi {{evt.instructor_fname}},
+{% if subject %}{{evt.name}} on {{evt_date}} - please confirm class supplies{% else %}Hi {{evt.instructor_name}},
 
 Thanks for agreeing to teach {{evt.name}} on {{evt_date}}.
 

--- a/protohaven_api/integrations/templates/instructor_class_canceled.jinja2
+++ b/protohaven_api/integrations/templates/instructor_class_canceled.jinja2
@@ -1,4 +1,4 @@
-{% if subject %}Your class '{{evt.name}}' was canceled{% else %}Hi {{evt.instructor_fname}},
+{% if subject %}Your class '{{evt.name}}' was canceled{% else %}Hi {{evt.instructor_name}},
 
 Unfortunately, we had to cancel your class {{evt.name}} (scheduled for {{evt.start_date.strftime("%B %-d")}})
 

--- a/protohaven_api/integrations/templates/instructor_class_confirmed.jinja2
+++ b/protohaven_api/integrations/templates/instructor_class_confirmed.jinja2
@@ -2,7 +2,7 @@
 {% if subject %}
 {{evt.name}} is on for {{evt_date}}!
 {% else %}
-Hi {{evt.instructor_fname}},
+Hi {{evt.instructor_name}},
 
 Get excited! Your class {{evt.name}} has {{evt.attendee_count}} student{% if evt.attendee_count != 1 %}s{% endif %} and will be running on {{evt_date}}.
 

--- a/protohaven_api/integrations/templates/instructor_log_reminder.jinja2
+++ b/protohaven_api/integrations/templates/instructor_log_reminder.jinja2
@@ -1,4 +1,4 @@
-{% if subject %}{{evt.name}}: Please submit instructor log{% else %}Hi {{evt.instructor_fname}},
+{% if subject %}{{evt.name}}: Please submit instructor log{% else %}Hi {{evt.instructor_name}},
 
 This is a friendly reminder to submit your instructor log (if you haven't already) to receive payment for the class, and to grant clearances to students.
 

--- a/protohaven_api/integrations/templates/instructor_low_attendance.jinja2
+++ b/protohaven_api/integrations/templates/instructor_low_attendance.jinja2
@@ -3,7 +3,7 @@
 {% if subject %}
 {{evt.name}} on {{evt_date}} - help us find {{avail}} more student(s)!
 {% else %}
-Hi {{evt.instructor_fname}},
+Hi {{evt.instructor_name}},
 
 Thanks for agreeing to teach {{evt.name}} on {{evt_date}}! To maximize your impact, we need your help to find {{avail}} additional student{% if avail != 1 %}s{% endif %} to take the class.
 

--- a/protohaven_api/integrations/templates/shift_no_techs.jinja2
+++ b/protohaven_api/integrations/templates/shift_no_techs.jinja2
@@ -4,7 +4,8 @@
 @TechLeads: no techs assigned for {{shift}} have signed in. [Expecting](https://api.protohaven.org/techs#cal) any of:
 
 {% for t in onduty  %}
-- {{t.name}} ({{t.email}})
+- {% if t.discord_user %}@{{t.discord_user}}{% else %}{{t.name}} ({{t.email}}){% endif %}
+
 {% endfor %}
 
 Please check immediately for techs on duty.

--- a/protohaven_api/scripts/cronicle_qa_tests.py
+++ b/protohaven_api/scripts/cronicle_qa_tests.py
@@ -3,6 +3,7 @@
 import argparse
 import datetime
 import logging
+import sys
 import time
 from typing import Any, Callable, Dict, List, Tuple
 
@@ -73,9 +74,11 @@ def run_cronicle_sync(event_id: str, image: str, params: dict):
                 timeout=REQ_TIMEOUT,
                 verify=False,
             ).json()
-            log.info(str(rep))
+            # log.info(str(rep))
             running[rid] = rep["job"].get("complete") != 1
-        log.info(f"Running: {running}")
+        if running[rid]:
+            sys.stderr.write(".")
+        # log.info(f"Running: {running[rid]}")
         code = rep["job"].get("code")
         if True not in running.values():
             log.info(rep["job"].get("description", f"job completed with code {code}"))


### PR DESCRIPTION
* Fix wrong use of `instructor_fname` instead of `instructor_name`
* Improve logging
* Revert the Neon ID assignment in Airtable for classes which get reverted due to Neon errors (so they can retry)
* Use `discord_user` when present for alerting on missed tech shifts