### PR TITLE
Fix /whoami when no roles in account

### DIFF
--- a/protohaven_api/handlers/index.py
+++ b/protohaven_api/handlers/index.py
@@ -41,7 +41,7 @@ def whoami():
         "email": acct.email,
         "neon_id": acct.neon_id,
         "clearances": acct.clearances,
-        "roles": [v["name"] for v in acct.roles],
+        "roles": [v["name"] for v in (acct.roles or [])],
     }
 
 

--- a/protohaven_api/handlers/index_test.py
+++ b/protohaven_api/handlers/index_test.py
@@ -33,6 +33,19 @@ def test_whoami(client):
     }
 
 
+def test_whoami_no_roles(client):
+    """test /whoami returns session info even if no role data"""
+    setup_session(client, roles=None)
+    response = client.get("/whoami")
+    assert json.loads(response.data.decode("utf8")) == {
+        "fullname": "First Last",
+        "email": "foo@bar.com",
+        "neon_id": 1234,
+        "clearances": ["C1", "C2"],
+        "roles": [],
+    }
+
+
 def test_class_listing(mocker, client):
     """Test class_listing function returns sorted class list with airtable data"""
     m1 = mocker.MagicMock(

--- a/protohaven_api/testing.py
+++ b/protohaven_api/testing.py
@@ -66,23 +66,33 @@ def fixture_client():
     ).test_client()
 
 
-def setup_session(client, roles=None):
+def setup_session(client, roles=True):
     """Add session details to client fixture"""
     with client.session_transaction() as session:
         session["neon_id"] = 1234
+
+        acf = [
+            {
+                "name": "Clearances",
+                "optionValues": [{"name": "C1"}, {"name": "C2"}],
+            },
+        ]
+        # It's important to support setting roles to [], None (not listed in custom fields),
+        # and a default value. This is why we use `True` as the signal here to apply defaults
+        if roles is not None:
+            acf.append(
+                {
+                    "name": "API server role",
+                    "optionValues": (
+                        [{"name": "Board Member"}] if roles is True else roles
+                    ),
+                }
+            )
+
         session["neon_account"] = {
             "individualAccount": {
                 "accountId": 1234,
-                "accountCustomFields": [
-                    {
-                        "name": "Clearances",
-                        "optionValues": [{"name": "C1"}, {"name": "C2"}],
-                    },
-                    {
-                        "name": "API server role",
-                        "optionValues": roles or [{"name": "Board Member"}],
-                    },
-                ],
+                "accountCustomFields": acf,
                 "primaryContact": {
                     "firstName": "First",
                     "lastName": "Last",


### PR DESCRIPTION
This is breaking discord association for new members, as they have no roles and so the `/members` page fails to load for them.