### PR TITLE
Fix eventbrite cost extraction

### DIFF
--- a/protohaven_api/integrations/models.py
+++ b/protohaven_api/integrations/models.py
@@ -787,7 +787,7 @@ class Event:  # pylint: disable=too-many-public-methods
             yield {
                 "id": tc["id"],
                 "name": tc["name"],
-                "price": float(tc["cost"]["major_value"]),
+                "price": 0 if tc.get("free") else float(tc["cost"].get("major_value")),
                 "total": tc["quantity_total"],
                 "sold": tc["quantity_sold"],
             }

--- a/protohaven_api/integrations/models_test.py
+++ b/protohaven_api/integrations/models_test.py
@@ -463,6 +463,24 @@ def test_event_properties():
         assert evt.supply_state == "Ordered"
 
 
+def test_event_ticket_options_free():
+    """Ensure that missing `cost.major_value` on free events is handled"""
+    e = Event()
+    e.eventbrite_data = {
+        "ticket_classes": [
+            {
+                "free": True,
+                "id": 111,
+                "name": "General",
+                "cost": {},
+                "quantity_total": 10,
+                "quantity_sold": 1,
+            }
+        ],
+    }
+    assert list(e.ticket_options)[0]["price"] == 0
+
+
 def test_none_vs_zero_attendee_count():
     """Specifically test handling of attendee count on various falsey data"""
     e = Event()


### PR DESCRIPTION
Free classes don't have a `major_value` field