### PR TITLE
Improve limits on discord role syncing; fix templates

### DIFF
--- a/protohaven_api/automation/roles/roles.py
+++ b/protohaven_api/automation/roles/roles.py
@@ -153,8 +153,8 @@ def singleton_role_sync(neon_member, neon_roles, discord_roles):
             yield "ADD", to_add, "indicated by Neon CRM"
 
 
-def gen_role_intents(
-    user_filter, exclude_users, destructive, max_user_intents
+def gen_role_intents(  # pylint: disable=too-many-statements
+    user_filter, exclude_users, destructive, max_users_added, max_users_removed
 ):  # pylint: disable=too-many-locals, too-many-branches
     """Generate all intents based on data from discord and neon"""
     log.info("Fetching all active members")
@@ -183,7 +183,8 @@ def gen_role_intents(
     discord_members = list(comms.get_all_members())
     log.info(f"Got {len(discord_members)}; example {discord_members[0]}")
     discord_members.sort(key=lambda m: m[2])
-    modified_users = set()  # for early cutoff on `max_user_intents`
+    additions = set()  # for early cutoff on `max_users_added`
+    revocations = set()  # for early cutoff on `max_users_removed`
 
     if user_filter is not None:
         log.warning(f"Filtering to provided user list: {user_filter}")
@@ -212,23 +213,38 @@ def gen_role_intents(
             }
 
         discord_roleset = {r for r, _ in assigned_roles if r in SYNC_ROLES}
-        log.info(f"singleton_role_sync {neon_member} {neon_roleset} {discord_roleset}")
+        log.debug(
+            f"Syncing roles for #{intent.neon_id} {intent.name} @{discord_id}: "
+            f"membership={neon_member} neon_roles={neon_roleset} discord_roles={discord_roleset}"
+        )
         for action, role, reason in singleton_role_sync(
             neon_member, neon_roleset, discord_roleset
         ):
-            if action == "REVOKE" and not destructive:
-                log.debug(
-                    f"Omitting destructive action {action} {role} ({reason}) for {intent}"
-                )
-                continue
-            if action == "REVOKE" and role == "Members":
-                log.debug(
-                    "Omitting Members revocation until further agreement by members reached"
-                )
-                continue
-            modified_users.add(discord_id)
-            if len(modified_users) > max_user_intents:
-                break
+            if action == "REVOKE":
+                if not destructive:
+                    log.debug(
+                        f"Omitting destructive action {action} {role} ({reason}) for {intent}"
+                    )
+                    continue
+                if role == "Members":
+                    log.debug(
+                        "Omitting Members revocation until further agreement by members reached"
+                    )
+                    continue
+                if len(revocations) >= max_users_removed:
+                    log.debug(
+                        f"Max users removed reached; skipping {action} {role} ({reason})"
+                    )
+                    continue
+                revocations.add(discord_id)
+            elif action == "ADD":
+                if len(additions) >= max_users_added:
+                    log.debug(
+                        f"Max users added reached; skipping {action} {role} ({reason})"
+                    )
+                    continue
+                additions.add(discord_id)
+
             yield replace(intent, action=action, role=role, reason=reason)
 
 

--- a/protohaven_api/automation/roles/roles_test.py
+++ b/protohaven_api/automation/roles/roles_test.py
@@ -114,7 +114,7 @@ def test_gen_role_intents_limited_and_sorted(mocker):
     usrs = [(f"id{i}", f"nick{i}", d(-i), [("Techs", 1234567890)]) for i in range(100)]
     assert usrs[0][0] == "id0"  # Youngest user first
     mocker.patch.object(r.comms, "get_all_members", return_value=usrs)
-    got = list(r.gen_role_intents(None, None, True, 20))
+    got = list(r.gen_role_intents(None, None, True, 20, 20))
     assert len(got) == 20  # Cutoff at the passed max
     assert got[0].discord_id == "id99"  # Oldest user is acted upon first
 
@@ -145,7 +145,7 @@ def test_gen_role_intents_departing_member(mocker):
             ("discord_id", "nickname", d(0), [("Members", "memid")]),
         ],
     )
-    assert list(r.gen_role_intents(None, None, True, 20)) == []
+    assert list(r.gen_role_intents(None, None, True, 10, 10)) == []
 
 
 def test_gen_role_intents_match(mocker):
@@ -175,7 +175,7 @@ def test_gen_role_intents_match(mocker):
             ("discord_id", "nickname", d(0), [("Techs", "techid")]),
         ],
     )
-    got = list(r.gen_role_intents(None, None, True, 20))
+    got = list(r.gen_role_intents(None, None, True, 10, 10))
     want_base = r.DiscordIntent(
         neon_id=123,
         name="A B",
@@ -212,7 +212,7 @@ def test_gen_role_intents_no_neon(mocker):
             ("discord_id", "nickname", d(0), [("Techs", "techid")]),
         ],
     )
-    got = list(r.gen_role_intents(None, None, True, 20))
+    got = list(r.gen_role_intents(None, None, True, 10, 10))
     assert got == [
         r.DiscordIntent(
             discord_id="discord_id",

--- a/protohaven_api/commands/roles.py
+++ b/protohaven_api/commands/roles.py
@@ -43,9 +43,21 @@ class Commands:  # pylint: disable=too-few-public-methods
         ),
         arg(
             "--max_users_affected",
-            help="Only allow at most this number of users to receive role changes",
+            help="DEPRECATED - does nothing. Use --max_users_(added|removed)",
             type=int,
             default=10,
+        ),
+        arg(
+            "--max_users_added",
+            help="Limits the maximum number of users who receive role additions this run",
+            type=int,
+            default=5,
+        ),
+        arg(
+            "--max_users_removed",
+            help="Limits the maximum number of users where role revocations are processed",
+            type=int,
+            default=5,
         ),
         arg(
             "--destructive",
@@ -71,7 +83,11 @@ class Commands:  # pylint: disable=too-few-public-methods
         intents = {
             i.as_key(): i
             for i in roles.gen_role_intents(
-                user_filter, exclude_users, args.destructive, args.max_users_affected
+                user_filter,
+                exclude_users,
+                args.destructive,
+                max_users_added=args.max_users_added,
+                max_users_removed=args.max_users_removed,
             )
         }
         log.info(f"Fetched {len(intents)} intents")

--- a/protohaven_api/handlers/techs.py
+++ b/protohaven_api/handlers/techs.py
@@ -455,7 +455,7 @@ def _notify_registration(account_id, event_id, action):
     if action != "register":
         verb = "unregistered from"
     msg = (
-        f"{acc.name} {verb} via [/techs](https://api.protohaven.org/techs#events)"
+        f"{acc.name} {verb} via [/techs](https://api.protohaven.org/techs#events) "
         f"{evt.name} on {evt.start_date.strftime('%a %b %d %-I:%M %p')} "
         f"; {evt.capacity - len(attendees)} seat(s) remain"
     )

--- a/protohaven_api/integrations/comms_test.py
+++ b/protohaven_api/integrations/comms_test.py
@@ -427,13 +427,13 @@ HASHES = {
     "shop_tech_applications": "a011ed984ed4a302",  # pragma: allowlist secret
     "square_validation_action_needed": "8cf97c894e5171aa",  # pragma: allowlist secret
     "tech_daily_tasks": "950fc9858cdf56bd",  # pragma: allowlist secret
-    "tech_openings": "6212e17a71640d10",  # pragma: allowlist secret
+    "tech_openings": "dad9368b3192d473",  # pragma: allowlist secret
     "tool_sync_summary": "dcc01eae3a3b66a3",  # pragma: allowlist secret
     "verify_income": "4d24d1a819192eae",  # pragma: allowlist secret
     "violation_ongoing": "fcad4dda2bb81f53",  # pragma: allowlist secret
     "violation_started": "12527581a8fbdd2d",  # pragma: allowlist secret
     "volunteer_refresh_summary": "a2858fc78352ea01",  # pragma: allowlist secret
-    "wiki_backup_summary": "df48c038b0dfe724",  # pragma: allowlist secret
+    "wiki_backup_summary": "453ee303bc5f3a02",  # pragma: allowlist secret
 }
 
 

--- a/protohaven_api/integrations/templates/tech_openings.jinja2
+++ b/protohaven_api/integrations/templates/tech_openings.jinja2
@@ -12,5 +12,5 @@ New classes for tech backfill:
 
 You can pay at the front desk via Square (select "Walk-In (3 Hr Class / add price)", set to the cost listed above, charge as normal)
 
-**Go to https://api.protohaven.org/techs#events, sign in, and click `Register` to register for the class.**
+**Go to [/techs#events](https://api.protohaven.org/techs#events), sign in, and click `Register` to register for the class.**
 {% endif %}


### PR DESCRIPTION
New members were getting blocked from role additions because of a backlog of role revocations - this splits the limits for additions and revocations so one can occur independently of the other.