### PR TITLE
Updates admin login URL

### DIFF
--- a/svelte/src/routes/+page.svelte
+++ b/svelte/src/routes/+page.svelte
@@ -10,7 +10,7 @@ Test change
 
 <h3>Roles</h3>
 <ul>
-  <li><a href="http://localhost:5173/admin/login_as?neon_id=1797">Login</a> as Instructor/PrivateInstructor/EduLead</li>
+  <li><a href="/admin/login_as?neon_id=1727">Login</a> as Instructor/PrivateInstructor/EduLead</li>
 </ul>
 
 <h3>Directory</h3>


### PR DESCRIPTION
Updates admin login URL to use an account that appears to be in the nocodb dump.

The previous account number (1797) returns a not found error from nocodb. The dump.sql does mention this account number, so it might be worth following up on the root cause just in case this happens again for some reason. Also makes the URL relative.