### PR TITLE
Normalize event attendee emails

### DIFF
--- a/protohaven_api/automation/classes/builder.py
+++ b/protohaven_api/automation/classes/builder.py
@@ -53,7 +53,7 @@ def get_unscheduled_instructors(start, end, require_active=True):
         require_teachable_classes=True,
         require_active=require_active,
     ).items():
-        if already_scheduled[email.lower()]:
+        if already_scheduled[email.lower().strip()]:
             continue  # Don't nag folks that already have their classes set up
         yield (name, email)
 
@@ -286,6 +286,9 @@ class ClassEmailBuilder:  # pylint: disable=too-many-instance-attributes
 
     def _build_registrant_notification(self, evt, action, a):
         """Build notification for a registrant `a` about event `evt`"""
+        if a.email is None:
+            self.log.error(f"Skipping email to attendee {a.fname}; no email given")
+            return
         if self.notified(a.email, evt, action.day_offset):
             self.log.debug(
                 f"Skipping email to attendee {a.fname} ({a.email}); already notified"

--- a/protohaven_api/automation/classes/builder_test.py
+++ b/protohaven_api/automation/classes/builder_test.py
@@ -20,20 +20,26 @@ def _upcoming_event(mocker):
         neon_id=4567,
     )
     a.name = "Test Attendee"
+    a2 = mocker.MagicMock(
+        fname="Noemail",
+        email=None,
+        neon_id=7890,
+    )
+    a2.name = "Noemail Alwayshidden"
     m = mocker.MagicMock(
         neon_id=1234,
         start_date=d(EVT_DAY, 18),
         end_date=d(EVT_DAY, 21),
         capacity=6,
-        attendee_count=1,
-        occupancy=1 / 6,
+        attendee_count=2,
+        occupancy=2 / 6,
         in_blocklist=lambda: False,
         instructor_email="inst@ructor.com",
         instructor_name="Test",
         volunteer=True,
         supply="Supply Check Needed",
         supply_cost=5,
-        attendees=[a],
+        attendees=[a, a2],
     )
     m.name = "Test Event"
     return m
@@ -177,7 +183,7 @@ Tc = namedtuple("Tc", "desc,now,evt_ovr,want")
                 {
                     "id": 1234,
                     "target": "Instructor (inst@ructor.com)",
-                    "subject": "Test Event on January 31 - help us find 5 more student(s)!",
+                    "subject": "Test Event on January 31 - help us find 4 more student(s)!",
                 },
                 {
                     "id": "N/A",

--- a/protohaven_api/integrations/models.py
+++ b/protohaven_api/integrations/models.py
@@ -500,9 +500,10 @@ class Attendee:
     @property
     def email(self):
         """Email address of the attendee"""
-        return self.neon_raw_data.get("email") or self.eventbrite_data.get(
+        email = self.neon_raw_data.get("email") or self.eventbrite_data.get(
             "profile", {}
         ).get("email")
+        return email.strip().lower() if email else None
 
     @property
     def fname(self):

--- a/protohaven_api/integrations/models_test.py
+++ b/protohaven_api/integrations/models_test.py
@@ -388,7 +388,7 @@ def test_event_properties():
         {
             "accountId": 1,
             "registrationStatus": "SUCCEEDED",
-            "email": "a@b.com",
+            "email": "A@b.COM    ",
             "firstName": "first",
             "lastName": "last",
         }
@@ -398,7 +398,11 @@ def test_event_properties():
             "id": 1,
             "cancelled": False,
             "refunded": False,
-            "profile": {"first_name": "first", "last_name": "last", "email": "a@b.com"},
+            "profile": {
+                "first_name": "first",
+                "last_name": "last",
+                "email": "A@b.COM     ",
+            },
         }
     ]
     tickets = [


### PR DESCRIPTION
This was causing checks for previous notifications to fail for event registrants with some capitalized letters in their email address.

Email is case-insensitive, and other paths to email fetching do some normalization (lowercasing, removing whitespace etc.). However the path for the Attendee model was missed.

Also noticed tech backfills would technically fire off emails, although they would error due to the email not being found. Added an early break if the attendee email is None so that we don't attempt to send emails to None,