### PR TITLE
Properly review square subscription invoices

### DIFF
--- a/protohaven_api/commands/finances_test.py
+++ b/protohaven_api/commands/finances_test.py
@@ -22,6 +22,7 @@ def test_transaction_alerts_ok(mocker, cli):
     mocker.patch.object(
         f.sales, "get_customer_name_map", return_value={"cust_id": "Foo Bar"}
     )
+    mocker.patch.object(f.sales, "get_unpaid_invoices_by_id", return_value={})
     mocker.patch.object(
         f.sales,
         "get_subscription_plan_map",
@@ -41,6 +42,7 @@ def test_transaction_alerts_ok(mocker, cli):
                     "plan_variation_id": "var_id",
                     "customer_id": "cust_id",
                     "charged_through_date": d(0).isoformat(),
+                    "invoice_ids": [],
                 }
             ]
         },
@@ -48,6 +50,41 @@ def test_transaction_alerts_ok(mocker, cli):
     mocker.patch.object(f.sales, "subscription_tax_pct", return_value=7.0)
     got = cli("transaction_alerts", [])
     assert not got
+
+
+def test_transaction_alerts_active_with_unpaid_invoice(mocker, cli):
+    """ACTIVE subscription with unpaid invoice should raise alert"""
+    mocker.patch.object(
+        f.sales, "get_customer_name_map", return_value={"cust_id": "Test Customer"}
+    )
+    mocker.patch.object(
+        f.sales,
+        "get_subscription_plan_map",
+        return_value={"plan_id": ("Test Plan", 1000)},
+    )
+    mocker.patch.object(
+        f.sales, "get_unpaid_invoices_by_id", return_value=[("inv_id", "$10.00")]
+    )
+    mock_sub = {
+        "id": "sub_id",
+        "status": "ACTIVE",
+        "plan_variation_id": "plan_id",
+        "customer_id": "cust_id",
+        "invoice_ids": ["inv_id", "inv2_id"],
+        "charged_through_date": d(10).isoformat(),
+    }
+    mocker.patch.object(
+        f.sales, "get_subscriptions", return_value={"subscriptions": [mock_sub]}
+    )
+    mocker.patch.object(f.sales, "subscription_tax_pct", return_value=7.0)
+    mocker.patch.object(f, "tznow", return_value=d(0))
+
+    got = cli("transaction_alerts", [])
+
+    assert got and len(got) == 1
+    assert "charged through 2025-01-11, unpaid [$10.00]" in got[0]["body"]
+    assert "inv_id" in got[0]["body"]
+    assert "inv2_id" not in got[0]["body"]
 
 
 def test_validate_memberships_empty(mocker):

--- a/protohaven_api/integrations/sales.py
+++ b/protohaven_api/integrations/sales.py
@@ -36,6 +36,17 @@ def get_invoice(invoice_id):
     raise RuntimeError(result.errors)
 
 
+def get_unpaid_invoices_by_id():
+    """Fetch all unpaid invoices and return them keyed by ID"""
+    result = client().invoices.list_invoices(get_config("square/location"))
+    if not result.is_success():
+        raise RuntimeError(result.errors)
+
+    for i in result.body["invoices"]:
+        if i["status"] != "PAID":
+            yield (i["id"], i["invoice_number"])
+
+
 def subscription_tax_pct(sub, price):
     """Compute the tax percentage for a given subscription. Note that only
     some subscriptions have the `tax_percentage` field, others must be computed

--- a/protohaven_api/integrations/sales_test.py
+++ b/protohaven_api/integrations/sales_test.py
@@ -1,0 +1,24 @@
+"""Test of sales integration module"""
+
+from protohaven_api.integrations import sales as s
+
+
+def test_get_unpaid_invoices_by_id(mocker):
+    """Test fetching unpaid invoices keyed by ID"""
+    mock_invoices = [
+        {"id": "inv1", "invoice_number": "001", "status": "UNPAID"},
+        {"id": "inv2", "invoice_number": "002", "status": "PAID"},
+        {"id": "inv3", "invoice_number": "003", "status": "PARTIALLY_PAID"},
+    ]
+    mock_result = mocker.Mock()
+    mock_result.is_success.return_value = True
+    mock_result.body = {"invoices": mock_invoices}
+
+    mocker.patch.object(s, "client")
+    mock_client_instance = mocker.Mock()
+    mock_client_instance.invoices.list_invoices.return_value = mock_result
+    s.client.return_value = mock_client_instance
+
+    got = dict(s.get_unpaid_invoices_by_id())
+    expected = {"inv1": "001", "inv3": "003"}
+    assert got == expected


### PR DESCRIPTION
We were relying on the "charged_through" field of square subscriptions, which doesn't actually indicate whether the charges were paid or not.

This change looks at all invoices and ensures that unpaid invoices due to subscriptions are called out in alerts.