### PR TITLE
Enumerate protohaven-specific holidays and drive tech shifts with them

### DIFF
--- a/protohaven_api/automation/classes/validation.py
+++ b/protohaven_api/automation/classes/validation.py
@@ -4,6 +4,8 @@ from functools import reduce
 
 import holidays
 
+from protohaven_api.automation.techs.techs import ph_holidays
+
 
 def date_range_overlaps(a0, a1, b0, b1):
     """Return True if [a0,a1] and [b0,b1] overlap"""
@@ -84,6 +86,8 @@ def validate_candidate_class_time(  # pylint: disable=too-many-return-statements
         # Skip holiday classes
         if t0 in us_holidays:
             return False, "Occurs on a US holiday"
+        if t0 in ph_holidays:
+            return False, "Occurs on a Protohaven holiday"
 
         # Skip if instructor is already busy on this day
         for occ in inst_occupancy:

--- a/protohaven_api/automation/techs/techs.py
+++ b/protohaven_api/automation/techs/techs.py
@@ -6,7 +6,7 @@ import re
 from collections import defaultdict
 from typing import NotRequired, Optional, TypedDict, cast
 
-import holidays
+from holidays.countries.united_states import UnitedStates
 
 from protohaven_api.integrations import airtable, neon
 from protohaven_api.integrations.models import Member
@@ -16,7 +16,31 @@ DEFAULT_FORECAST_LEN = 16
 
 log = logging.getLogger("protohaven_api.automation.techs.techs")
 
-us_holidays = holidays.country_holidays("US")
+
+class ProtohavenHolidays(UnitedStates):
+    """Observed holidays for Protohaven, per our website
+    https://www.protohaven.org/contact/
+    """
+
+    def _populate(self, year):
+        self._year = year
+        # See https://holidays.readthedocs.io/en/latest/examples
+        # We explicitly *don't* prepopulate, as we want to opt in specific days
+        self._add_holiday_dec_31("New Year's Eve")
+        self._add_holiday_jan_1("New Year's Day")
+        self._add_holiday_3rd_mon_of_jan("Martin Luther King Day")
+        self._add_holiday_0_days_prior_easter("Easter Sunday")
+        self._add_holiday_last_mon_of_may("Memorial Day")
+        self._add_holiday_jun_19("Juneteenth")
+        self._add_holiday_jul_4("Independence Day")
+        self._add_holiday_1st_mon_of_sep("Labor Day")
+        self._add_holiday_4th_thu_of_nov("Thanksgiving Day")
+        self._add_holiday_1_day_past_4th_thu_of_nov("Day After Thanksgiving")
+        self._add_holiday_dec_24("Christmas Eve")
+        self._add_holiday_dec_25("Christmas Day")
+
+
+ph_holidays = ProtohavenHolidays()
 
 
 class ShiftOverride(TypedDict):
@@ -124,7 +148,7 @@ def create_calendar_view(  # pylint: disable=too-many-locals, too-many-nested-bl
             )
 
             # On holidays, we assume by default that nobody is on duty.
-            people_in = shift_map.get((wd, ap), []) if d not in us_holidays else []
+            people_in = shift_map.get((wd, ap), []) if d not in ph_holidays else []
 
             shift_people = []
             for p in people_in:  # remove if outside of the tech's tenure
@@ -153,7 +177,7 @@ def create_calendar_view(  # pylint: disable=too-many-locals, too-many-nested-bl
 
         day: Day = {
             "date": dstr,
-            "is_holiday": d in us_holidays,
+            "is_holiday": d in ph_holidays,
             "AM": shifts["AM"],
             "PM": shifts["PM"],
         }

--- a/protohaven_api/automation/techs/techs_test.py
+++ b/protohaven_api/automation/techs/techs_test.py
@@ -6,6 +6,27 @@ from protohaven_api.automation.techs import techs as t
 from protohaven_api.testing import d
 
 
+def test_holiday_customization():
+    """Basic check to ensure holiday calendar is working"""
+    got = set(t.ProtohavenHolidays(years=2025).values())
+    assert {
+        "New Year's Eve",
+        "New Year's Day",
+        "Martin Luther King Day",
+        "Easter Sunday",
+        "Memorial Day",
+        "Juneteenth",
+        "Independence Day",
+        "Labor Day",
+        "Thanksgiving Day",
+        "Day After Thanksgiving",
+        "Christmas Eve",
+        "Christmas Day",
+    } == got
+    # Monday is 0, Sunday is 6 in Python's weekday()
+    assert t.ProtohavenHolidays(years=2025).get_named("Easter Sunday")[0].weekday() == 6
+
+
 @pytest.mark.parametrize(
     "test_date,ovr,want_am,is_holiday",
     [

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ flask-sock==0.7.0
 google-api-core==2.14.0
 google-api-python-client==2.109.0
 gunicorn==21.2.0
-holidays==0.45
+holidays==0.87
 Jinja2==3.1.2
 Markdown==3.6
 numpy==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asana==5.0.3
+asana==5.2.2
 beautifulsoup4==4.12.2
 detect-secrets==1.5.0
 # audioop-lts==0.2.2
@@ -10,7 +10,7 @@ flask-sock==0.7.0
 google-api-core==2.14.0
 google-api-python-client==2.109.0
 gunicorn==21.2.0
-holidays==0.45
+holidays==0.87
 Jinja2==3.1.2
 Markdown==3.6
 numpy==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ flask-sock==0.7.0
 google-api-core==2.14.0
 google-api-python-client==2.109.0
 gunicorn==21.2.0
-holidays==0.87
+holidays==0.45
 Jinja2==3.1.2
 Markdown==3.6
 numpy==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ pyotp==2.9.0
 pytest==8.3.3
 pytest-asyncio==0.23.8
 pytest-mock==3.12.0
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 python-dotenv==0.21.1
 PyYAML==6.0.1
 rapidfuzz==3.11.0


### PR DESCRIPTION
Fixes #443

Also now checks both US and Protohaven holidays when scheduling classes, just to be sure we're not running a class when we're closed (e.g. day after thanksgiving)