### PR TITLE
Eliminate clearance code usage in favor of tool codes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -113,7 +113,6 @@ nocodb:
     tools_and_equipment:
       areas: "mkb05bg2fnjp5af"
       tools: "m70mnnu12pnc5fx"
-      clearances: "mt6i54nze3zpqsg"
       tool_reports: "mon1qz7fs6mp0j6"
     class_automation:
       clearance_codes: "mzgdpodpavc8x2x"
@@ -183,7 +182,6 @@ airtable:
       base_id: "appbIlORlmbIxNU1L"
       areas: "tblpZf4XLHiptLLzL"
       tools: "tblalZYdLVoTICzE6"
-      clearances: "tblsDjiWCOQLgDCHd"
       tool_reports: "tblZbQcalfrvUiNM6"
     class_automation:
       token: ${AIRTABLE_TOKEN_CLASS_AUTOMATION}

--- a/protohaven_api/automation/membership/clearances_test.py
+++ b/protohaven_api/automation/membership/clearances_test.py
@@ -26,9 +26,6 @@ def test_update_patch(mocker):
             mocker.MagicMock(neon_id=123, company_id=456, clearances=["CLEAR1"])
         ],
     )
-    mocker.patch.object(
-        c.airtable, "get_clearance_to_tool_map", return_value={"MWB": ["ABG", "RBP"]}
-    )
     mocker.patch.object(c.neon, "set_clearances", return_value="Success")
     mock_notify = mocker.patch.object(c.mqtt, "notify_clearance")
 
@@ -186,8 +183,7 @@ def test_build_recert_env(mocker):
     }
 
     mock_instructor_clearances = [
-        ("test@example.com", ["clearance1"], [], d(1)),  # maps to tool1
-        ("test@example.com", [], ["tool1"], d(0)),
+        ("test@example.com", ["tool1"], d(1)),
     ]
     mock_reservations = {"123": {"tool1": [d(0)]}}
     mock_pending = mocker.MagicMock(neon_id="123", tool_code="tool1")
@@ -210,11 +206,6 @@ def test_build_recert_env(mocker):
         return_value=mock_instructor_clearances,
     )
     mocker.patch.object(c, "_structured_reservations", return_value=mock_reservations)
-    mocker.patch.object(
-        c,
-        "resolve_codes",
-        side_effect=lambda codes: [{"clearance1": "tool1"}.get(c) for c in codes],
-    )
 
     # Execute the function
     result = c.build_recert_env(d(0), 1300)

--- a/protohaven_api/commands/clearances.py
+++ b/protohaven_api/commands/clearances.py
@@ -76,14 +76,11 @@ class Commands:  # pylint: disable=too-few-public-methods
         earned = defaultdict(set)
         for (
             email,
-            clearance_codes,
             tool_codes,
             _,
         ) in sheets.get_passing_student_clearances(dt=dt, from_row=args.from_row):
             if user_filter and email.lower() not in user_filter:
                 continue
-            if clearance_codes:
-                earned[email.strip()].update(clearances.resolve_codes(clearance_codes))
             if tool_codes:
                 earned[email.strip()].update(tool_codes)
         log.info(f"Clearance list built; {len(earned)} users in list")

--- a/protohaven_api/commands/clearances_test.py
+++ b/protohaven_api/commands/clearances_test.py
@@ -40,21 +40,17 @@ def test_sync_clearances_e2e(mocker, cli):
         return_value=[
             (
                 "test@example.com",
-                ["code1", "code2"],
                 ["tool1", "tool2"],
                 d(0),
             )
         ],
-    )
-    mocker.patch.object(
-        C.clearances, "resolve_codes", lambda tc: [t + "_resolved" for t in tc]
     )
     m1 = mocker.patch.object(C.clearances, "update", return_value=["code1"])
     got = cli("sync_clearances", ["--apply"])
     m1.assert_called_with(
         "test@example.com",
         "PATCH",
-        {"code1_resolved", "code2_resolved", "tool1", "tool2"},
+        {"tool1", "tool2"},
         apply=True,
     )
     assert len(got) == 1

--- a/protohaven_api/handlers/admin.py
+++ b/protohaven_api/handlers/admin.py
@@ -49,10 +49,9 @@ def user_clearances():
 
     delta = []
     if request.method != "GET":
-        initial = [c.strip() for c in request.values.get("codes").split(",")]
-        if len(initial) == 0:
+        delta = [c.strip() for c in request.values.get("codes").split(",")]
+        if len(delta) == 0:
             return Response("Missing required param 'codes'", status=400)
-        delta = mclearance.resolve_codes(initial)
 
     for e in emails:
         try:

--- a/protohaven_api/handlers/admin_test.py
+++ b/protohaven_api/handlers/admin_test.py
@@ -13,12 +13,11 @@ def test_user_clearances_notifies_discord(mocker, client):
         rbac, "is_enabled", return_value=False
     )  # Disable to allow testing
     mocker.patch.object(a.mclearance, "update", return_value=[])
-    mocker.patch.object(a.mclearance, "resolve_codes", return_value=[])
     mocker.patch.object(a.comms, "send_discord_message")
 
     rep = client.patch(
         "/user/clearances",
-        data={"emails": "test@example.com", "codes": "CLEAR1,CLEAR2"},
+        data={"emails": "test@example.com", "codes": "C1,C2"},
     )
     a.comms.send_discord_message.assert_called_once()  # pylint: disable=no-member
     assert rep.status_code == 200
@@ -29,26 +28,16 @@ def test_user_clearances(mocker, client):
     mocker.patch.object(
         rbac, "is_enabled", return_value=False
     )  # Disable to allow testing
-    c1 = {"name": "CLEAR1", "code": "C1", "id": 1}
-    c2 = {"name": "CLEAR2", "code": "C2", "id": 2}
-    mocker.patch.object(
-        a.mclearance,
-        "resolve_codes",
-        return_value=[c1, c2],
-    )
     mocker.patch.object(a.comms, "send_discord_message")
-    mocker.patch.object(
-        a.airtable, "get_clearance_to_tool_map", return_value={"MWB": ["ABG", "RBP"]}
-    )
     mocker.patch.object(a.mclearance, "update", return_value="Success")
     rep = client.patch(
         "/user/clearances",
-        data={"emails": "test@example.com", "codes": "CLEAR1,CLEAR2"},
+        data={"emails": "test@example.com", "codes": "C1,C2"},
     )
 
     assert rep.status_code == 200
     a.mclearance.update.assert_called_with(  # pylint: disable=no-member
-        "test@example.com", "PATCH", [c1, c2]
+        "test@example.com", "PATCH", ["C1", "C2"]
     )
 
 

--- a/protohaven_api/integrations/sheets.py
+++ b/protohaven_api/integrations/sheets.py
@@ -9,7 +9,7 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 
 from protohaven_api.config import get_config, safe_parse_datetime
-from protohaven_api.integrations.airtable import ClearanceCode, Email, ToolCode
+from protohaven_api.integrations.airtable import Email, ToolCode
 
 log = logging.getLogger("integrations.sheets")
 
@@ -55,11 +55,9 @@ TOOLS_HDR = "Which tools?"
 
 def get_passing_student_clearances(
     dt=None, from_row=1300
-) -> Iterator[tuple[Email, list[ClearanceCode], list[ToolCode], datetime.datetime]]:
+) -> Iterator[tuple[Email, list[ToolCode], datetime.datetime]]:
     """Minimally parse and return instructor submissions after from_row in the sheet.
-
-    Yields a sequence of (email, clearance_codes, tool_codes) for each student that
-    passed a class.
+    Yields a sequence of clearance info for each student that passed a class.
     """
     for sub in get_instructor_submissions_raw(from_row):
         if dt is not None and sub["Timestamp"] < dt:
@@ -72,12 +70,6 @@ def get_passing_student_clearances(
             m.replace("(", "").replace(")", "").replace(",", "").strip() for m in mm
         ]
 
-        clearance_codes = sub.get(CLEARANCE_HDR)
-        clearance_codes = (
-            [s.split(":")[0].strip() for s in clearance_codes.split(",")]
-            if clearance_codes
-            else None
-        )
         tool_codes = sub.get(TOOLS_HDR)
         tool_codes = (
             [s.split(":")[0].strip() for s in tool_codes.split(",")]
@@ -85,7 +77,7 @@ def get_passing_student_clearances(
             else None
         )
         for e in emails:
-            yield (e.strip().lower(), clearance_codes, tool_codes, sub["Timestamp"])
+            yield (e.strip().lower(), tool_codes, sub["Timestamp"])
 
 
 def get_sign_ins_between(start, end):


### PR DESCRIPTION
Clearance codes are deprecated; Neon, Airtable and the instructor log form all now use individual tool codes to express clearances. 

This PR deletes all resolving of clearance codes to tool codes as it's no longer needed.

This refactor helps de-complicate the recert process (#484)