### PR TITLE
Modify get_instructor_readiness to join Neon with Airtable data based on Neon ID

### DIFF
--- a/protohaven_api/automation/classes/builder.py
+++ b/protohaven_api/automation/classes/builder.py
@@ -9,7 +9,7 @@ import threading
 from collections import defaultdict
 from enum import Enum
 from functools import lru_cache
-from typing import Any
+from typing import Any, Iterator
 
 from protohaven_api.automation.classes import events as eauto
 from protohaven_api.config import tz, tznow  # pylint: disable=import-error

--- a/protohaven_api/automation/classes/builder.py
+++ b/protohaven_api/automation/classes/builder.py
@@ -17,7 +17,7 @@ from protohaven_api.integrations import (  # pylint: disable=import-error
     airtable,
     neon_base,
 )
-from protohaven_api.integrations.airtable import InstructorID, ScheduledClass
+from protohaven_api.integrations.airtable import Email, NeonID, ScheduledClass
 from protohaven_api.integrations.comms import Msg
 
 log = logging.getLogger("class_automation.builder")
@@ -26,7 +26,7 @@ LOCALE_LOCK = threading.Lock()
 
 
 @lru_cache(maxsize=30)
-def get_account_email(account_id):
+def get_account_email(account_id: NeonID) -> Email:
     """Gets the matching email for a Neon account, by ID"""
     a = neon_base.fetch_account(account_id)
     if a:
@@ -34,7 +34,9 @@ def get_account_email(account_id):
     raise RuntimeError(f"Failed to resolve email for attendee: {account_id}")
 
 
-def get_unscheduled_instructors(start, end, require_active=True):
+def get_unscheduled_instructors(
+    start, end, require_active=True
+) -> Iterator[tuple[NeonID, Email]]:
     """Builds a set of instructors that do not have classes proposed or scheduled
     between `start` and `end`."""
     # Ensure start and end are timezone-aware
@@ -47,21 +49,21 @@ def get_unscheduled_instructors(start, end, require_active=True):
     for cls in airtable.get_class_automation_schedule():
         for t, _ in cls.sessions:
             if start <= t <= end:
-                already_scheduled[cls.instructor_email.lower()] = True
+                already_scheduled[cls.instructor_id] = True
     log.info(
         f"Already scheduled for interval {start} - {end}: {set(already_scheduled.keys())}"
     )
-    for name, email in airtable.get_instructor_email_map(
+    for nid, email in airtable.get_instructor_neon_id_map(
         require_teachable_classes=True,
         require_active=require_active,
     ).items():
-        if already_scheduled[email.lower().strip()]:
+        if already_scheduled[nid]:
             continue  # Don't nag folks that already have their classes set up
-        yield (name, email)
+        yield (nid, email)
 
 
 def gen_class_scheduled_alerts(
-    scheduled_by_instructor: dict[InstructorID, list[ScheduledClass]],
+    scheduled_by_instructor: dict[NeonID, list[ScheduledClass]],
 ):
     """Generate alerts about classes getting scheduled"""
     results = []

--- a/protohaven_api/automation/classes/builder_test.py
+++ b/protohaven_api/automation/classes/builder_test.py
@@ -60,8 +60,8 @@ def test_get_unscheduled_instructors(mocker):
     module but I'm including it here anyways."""
     mocker.patch.object(
         builder.airtable,
-        "get_instructor_email_map",
-        return_value={"Test Name": "test@email.com"},
+        "get_instructor_neon_id_map",
+        return_value={"1234": "test@email.com"},
     )
     mocker.patch.object(
         builder.airtable, "get_class_automation_schedule", return_value=[]
@@ -72,22 +72,22 @@ def test_get_unscheduled_instructors(mocker):
             safe_parse_datetime("2024-02-20"), safe_parse_datetime("2024-03-30")
         )
     )
-    assert got[0] == ("Test Name", "test@email.com")
+    assert got[0] == ("1234", "test@email.com")
 
 
 def test_gen_get_unscheduled_instructors_already_scheduled(mocker):
     """Test calendar reminder generation doesn't notify if already scheduled"""
     mocker.patch.object(
         builder.airtable,
-        "get_instructor_email_map",
-        return_value={"Test Name": "test@email.com"},
+        "get_instructor_neon_id_map",
+        return_value={"1234": "test@email.com"},
     )
     mocker.patch.object(
         builder.airtable,
         "get_class_automation_schedule",
         return_value=[
             mocker.MagicMock(
-                instructor_email="TeSt@email.com",
+                instructor_id="1234",
                 sessions=[
                     (
                         safe_parse_datetime("2024-02-21"),

--- a/protohaven_api/automation/classes/scheduler.py
+++ b/protohaven_api/automation/classes/scheduler.py
@@ -7,10 +7,9 @@ from collections import defaultdict
 from protohaven_api.automation.classes import validation as val
 from protohaven_api.automation.classes.validation import ClassAreaEnv
 from protohaven_api.config import get_config, safe_parse_datetime, tznow
-from protohaven_api.integrations import airtable, booked
+from protohaven_api.integrations import airtable, booked, neon_base
 from protohaven_api.integrations.airtable import AreaID, Interval, NeonID, RecordID
 from protohaven_api.integrations.airtable_base import get_all_records
-from protohaven_api.integrations.comms import Msg
 
 log = logging.getLogger("class_automation.scheduler")
 

--- a/protohaven_api/automation/classes/scheduler_test.py
+++ b/protohaven_api/automation/classes/scheduler_test.py
@@ -13,20 +13,21 @@ def test_push_class_to_schedule(mocker):
     mocker.patch.object(
         s.airtable, "append_classes_to_schedule", return_value=(200, None)
     )
+    mock_account = mocker.MagicMock()
+    mock_account.name = "Test Instructor"
+    mock_account.email = "a@b.com"
     mocker.patch.object(
-        s.airtable,
-        "get_instructor_email_map",
-        return_value={"test instructor": "a@b.com"},
+        s.neon_base,
+        "fetch_account",
+        return_value=mock_account,
     )
     now = tznow()
     mocker.patch.object(s, "tznow", return_value=now)
-    s.push_class_to_schedule(
-        "a@b.com", "20", [(d(0, 15), d(0, 18)), (d(1, 15), d(1, 18))]
-    )
+    s.push_class_to_schedule("1234", "20", [(d(0, 15), d(0, 18)), (d(1, 15), d(1, 18))])
     s.airtable.append_classes_to_schedule.assert_called_with(
         [
             {
-                "Instructor": "test instructor",
+                "Instructor": "Test Instructor",
                 "Email": "a@b.com",
                 "Sessions": f"{d(0,15).isoformat()},{d(1,15).isoformat()}",
                 "Class": ["20"],

--- a/protohaven_api/automation/classes/validation.py
+++ b/protohaven_api/automation/classes/validation.py
@@ -14,8 +14,8 @@ from protohaven_api.config import truncate_date, tznow
 from protohaven_api.integrations.airtable import (
     AreaID,
     Class,
-    InstructorID,
     Interval,
+    NeonID,
     RecordID,
     ScheduledClass,
 )
@@ -45,7 +45,7 @@ class ClassAreaEnv:
     exclusions: dict[RecordID, list[Exclusion]]
     clearance_exclusions: dict[RecordID, list[Exclusion]]
     area_occupancy: dict[AreaID, list[NamedInterval]]
-    instructor_occupancy: dict[InstructorID, list[NamedInterval]]
+    instructor_occupancy: dict[NeonID, list[NamedInterval]]
 
     @classmethod
     def with_defaults(cls):
@@ -134,7 +134,7 @@ us_holidays = holidays.US()  # pylint: disable=no-member
 
 
 def validate_candidate_class_session(  # pylint: disable=too-many-return-statements, too-many-locals
-    inst: InstructorID, i: Interval, session_idx: int, c: Class, env: ClassAreaEnv
+    inst: NeonID, i: Interval, session_idx: int, c: Class, env: ClassAreaEnv
 ) -> tuple[bool, str]:
     """Ensure solver.Class `c` being taught at `start` is not invalid for reasons e.g.
     - Scheduled on a US holiday

--- a/protohaven_api/handlers/instructor.py
+++ b/protohaven_api/handlers/instructor.py
@@ -70,7 +70,11 @@ def get_instructor_readiness(inst: list, caps: Optional[Any] = None) -> dict:
         result["discord_user"] = "OK"
     result["fullname"] = f"{inst_member.fname} {inst_member.lname}"
     if not caps:
-        caps = airtable.fetch_instructor_capabilities(result["fullname"])
+        # Use Neon ID to fetch capabilities instead of name
+        if result["neon_id"]:
+            caps = airtable.fetch_instructor_capabilities(result["neon_id"])
+        else:
+            caps = None
     if caps:
         result["airtable_id"] = caps["id"]
         if len(caps["classes"]) > 0:
@@ -314,6 +318,7 @@ def admin_data():
             {
                 "name": inst["fields"].get("Instructor") or "unknown",
                 "email": inst["fields"].get("Email") or "unknown",
+                "neon_id": inst["fields"].get("Neon ID") or None,
                 "active": inst["fields"].get("Active") or False,
             }
         )

--- a/protohaven_api/handlers/instructor.py
+++ b/protohaven_api/handlers/instructor.py
@@ -249,18 +249,10 @@ def instructor_class_details():
 
     email = email.lower()
     sched = get_dashboard_schedule_sorted(email)
-
-    # Look up the name on file in the capabilities list - this is used to match
-    # on manually entered calendar availability
-    caps_name = {v: k for k, v in airtable.get_instructor_email_map().items()}.get(
-        email, "<NOT FOUND>"
-    )
-
     return {
         "schedule": [c.as_response() for c in sched],
         "now": tznow(),
         "email": email,
-        "name": caps_name,
     }
 
 

--- a/protohaven_api/handlers/instructor_test.py
+++ b/protohaven_api/handlers/instructor_test.py
@@ -164,7 +164,6 @@ def test_class_details_both_email_and_session(mocker, inst_client):
     rbac.set_rbac(True)
     mocker.patch.object(rbac, "get_roles", return_value=[rbac.Role.INSTRUCTOR["name"]])
     mocker.patch.object(instructor, "get_dashboard_schedule_sorted")
-    mocker.patch.object(instructor.airtable, "get_instructor_email_map")
 
     rep = inst_client.get("/instructor/class_details?email=a@b.com")
     assert rep.status == "401 UNAUTHORIZED"

--- a/protohaven_api/handlers/instructor_test.py
+++ b/protohaven_api/handlers/instructor_test.py
@@ -197,6 +197,8 @@ def test_get_instructor_readiness_all_bad(mocker):
             ),
         ]
     )
+    # Verify fetch_instructor_capabilities was called with neon_id
+    instructor.airtable.fetch_instructor_capabilities.assert_called_once_with(12345)
     assert result == {
         "airtable_id": None,
         "neon_id": 12345,
@@ -234,6 +236,8 @@ def test_get_instructor_readiness_all_ok(mocker):
             ),
         ]
     )
+    # Verify fetch_instructor_capabilities was called with neon_id
+    instructor.airtable.fetch_instructor_capabilities.assert_called_once_with(12345)
     assert result == {
         "airtable_id": "inst_id",
         "neon_id": 12345,

--- a/protohaven_api/integrations/airtable.py
+++ b/protohaven_api/integrations/airtable.py
@@ -166,7 +166,7 @@ class ScheduledClass:  # pylint: disable=too-many-instance-attributes
         return cls(
             schedule_id=str(row["id"]),
             class_id=str(class_ids[0]),
-            neon_id=f.get("Neon ID") or None,
+            event_id=f.get("Neon ID") or None,
             name=_unwrap(f, "Name (from Class)"),
             hours=hours,
             period=datetime.timedelta(
@@ -239,7 +239,7 @@ class ScheduledClass:  # pylint: disable=too-many-instance-attributes
             else form_values["tool_usage_no"]
         )
         result += f"&{form_keys['tool_usage']}={tool_usage_value}"
-        result += f"&{form_keys['event_id']}={self.neon_id or 'UNKNOWN'}"
+        result += f"&{form_keys['event_id']}={self.event_id or 'UNKNOWN'}"
         for tc in tool_codes:
             result += f"&{form_keys['tool_codes']}={tc}"
         return result
@@ -259,12 +259,20 @@ class ScheduledClass:  # pylint: disable=too-many-instance-attributes
         """Returns days calculated from hours data"""
         return len(self.hours)
 
+    @property
+    def neon_id(self):
+        """Backward compatibility: returns event_id"""
+        return self.event_id
+
     def as_response(self, pass_emails=None):
         """Return a dict that can be used as a flask response, including prefill"""
         if not pass_emails:
             pass_emails = ["ATTENDEE_NAMES"]
+        result = asdict(self)
+        # Backward compatibility: include neon_id field
+        result["neon_id"] = self.event_id
         return {
-            **asdict(self),
+            **result,
             "prefill": self.prefill_form(pass_emails),
             "period": self.period.total_seconds() / (24 * 3600),
         }

--- a/protohaven_api/integrations/airtable_test.py
+++ b/protohaven_api/integrations/airtable_test.py
@@ -382,13 +382,13 @@ def test_fetch_instructor_teachable_classes(mocker):
     mock_records = [
         {
             "fields": {
-                "Instructor": "  John Doe  ",
+                "Neon ID": "12345",
                 "Class": ["class1", "class2"],
             }
         },
         {
             "fields": {
-                "Instructor": "jane smith",
+                "Neon ID": "67890",
                 "Class": ["class3"],
             }
         },
@@ -398,7 +398,7 @@ def test_fetch_instructor_teachable_classes(mocker):
     mocker.patch.object(a, "get_all_records", return_value=mock_records)
     got = a.fetch_instructor_teachable_classes()
 
-    expected = {"john doe": ["class1", "class2"], "jane smith": ["class3"]}
+    expected = {"12345": ["class1", "class2"], "67890": ["class3"]}
     assert got == expected
 
 

--- a/protohaven_api/integrations/airtable_test.py
+++ b/protohaven_api/integrations/airtable_test.py
@@ -484,7 +484,7 @@ def test_from_schedule(mocker):
     result = a.ScheduledClass.from_schedule(mock_row)
     assert result.schedule_id == "rec123"
     assert result.class_id == "cls789"
-    assert result.neon_id == "neon456"
+    assert result.event_id == "neon456"
     assert result.name == "Test Class"
     assert result.hours == [3, 3]
     assert result.days == 2

--- a/svelte/src/lib/instructor/class_details.svelte
+++ b/svelte/src/lib/instructor/class_details.svelte
@@ -1,4 +1,4 @@
-<script type="typescript">
+<script type="typescript" lang="ts">
 
 import {onMount} from 'svelte';
 import { Table, Button, Row, Col, Card, CardHeader, Alert, CardTitle, CardSubtitle, CardText, Icon, CardFooter, CardBody, Input, Spinner, FormGroup, Navbar, NavbarBrand, Nav, NavItem } from '@sveltestrap/sveltestrap';


### PR DESCRIPTION
- Updated fetch_instructor_capabilities to only accept neon_id parameter
- Changed get_instructor_readiness to use neon_id for Airtable lookups
- Updated fetch_instructor_teachable_classes to use Neon ID as key
- Added get_instructor_neon_id_map function for Neon ID to email mapping
- Updated admin_data endpoint to include neon_id field
- Updated all tests to use Neon ID instead of instructor name