### PR TITLE
Fix Eventbrite registration closing time

### DIFF
--- a/protohaven_api/commands/classes.py
+++ b/protohaven_api/commands/classes.py
@@ -469,6 +469,7 @@ class Commands:
                                 event.neon_id,
                                 event.price,
                                 event.capacity,
+                                clear_existing=True,
                             )
                         )
                     )


### PR DESCRIPTION
- Changed sales_end_relative.offset from 3600*24 to -3600*24 (24 hours BEFORE event instead of 24 hours AFTER event)
- Added clear_existing parameter to assign_pricing function
- When clear_existing=True, delete existing ticket classes before creating new one
- Updated classes.py command to pass clear_existing=True for Eventbrite events
- Added tests for assign_pricing with correct offset and clear_existing logic

Fixes issue where Eventbrite event registration was not closing 24h in advance.

Fixes #422