### PR TITLE
Several tweaks/fixes

### DIFF
--- a/protohaven_api/automation/classes/events.py
+++ b/protohaven_api/automation/classes/events.py
@@ -81,11 +81,12 @@ def fetch_upcoming_events(  # pylint: disable=too-many-locals
 
         # We need airtable data first so we can annotate
         airtable_raw = airtable_future.result() if airtable_future is not None else []
-        airtable_map = {
-            int(s["fields"].get("Neon ID")): s
-            for s in airtable_raw
-            if s["fields"].get("Neon ID")
-        }
+        airtable_map = {}
+        for s in airtable_raw:
+            # Post-rename in Airtable, we can remove "Neon ID" from here.
+            evt_id = s["fields"].get("Neon ID") or s["fields"].get("Event ID")
+            if evt_id:
+                airtable_map[int(evt_id)] = s
 
         # Since our event fetches are both paginated generators,
         # we have to submit them to the thread pool multiple times to

--- a/protohaven_api/automation/classes/scheduler.py
+++ b/protohaven_api/automation/classes/scheduler.py
@@ -74,7 +74,7 @@ def gen_class_and_area_stats(  # pylint: disable=too-many-locals
         last = c.sessions[-1][0]
         # We add some wiggle room to the window to account for scheduling at e.g.
         # 5pm on Jan 1st and 3pm on Jan 7th, even if period is 7 days
-        wiggle = max(datetime.timedelta(hours=12), c.period)
+        wiggle = min(datetime.timedelta(hours=12), c.period)
         exclusion_window = val.Exclusion(
             start=first - (c.period - wiggle),
             end=last + (c.period - wiggle),
@@ -87,9 +87,10 @@ def gen_class_and_area_stats(  # pylint: disable=too-many-locals
 
         # Clearances are excluded only based on start date, i.e. when a member
         # would have been able to register for the clearance
+        wiggle = min(datetime.timedelta(hours=12), clearance_exclusion_range)
         clearance_exclusion_window = val.Exclusion(
-            start=first - clearance_exclusion_range,
-            end=first + clearance_exclusion_range,
+            start=first - (clearance_exclusion_range - wiggle),
+            end=first + (clearance_exclusion_range - wiggle),
             main_date=first,  # Main date is included for reference
             origin=c.name,
         )

--- a/protohaven_api/automation/classes/scheduler.py
+++ b/protohaven_api/automation/classes/scheduler.py
@@ -72,9 +72,12 @@ def gen_class_and_area_stats(  # pylint: disable=too-many-locals
         # Repeats of the class are excluded based on the start and end run date
         first = c.sessions[0][0]
         last = c.sessions[-1][0]
+        # We add some wiggle room to the window to account for scheduling at e.g.
+        # 5pm on Jan 1st and 3pm on Jan 7th, even if period is 7 days
+        wiggle = max(datetime.timedelta(hours=12), c.period)
         exclusion_window = val.Exclusion(
-            start=first - c.period,
-            end=last + c.period,
+            start=first - (c.period - wiggle),
+            end=last + (c.period - wiggle),
             main_date=first,
             origin=c.name,
         )

--- a/protohaven_api/automation/classes/scheduler_test.py
+++ b/protohaven_api/automation/classes/scheduler_test.py
@@ -77,18 +77,18 @@ def test_gen_class_and_area_stats_exclusions(mocker):
     )
     env = s.gen_class_and_area_stats(d(20), d(70))
     assert [
-        tuple([d.strftime("%Y-%m-%d") for d in (dd.start, dd.end, dd.main_date)])
+        tuple([d.strftime("%Y-%m-%dT%H") for d in (dd.start, dd.end, dd.main_date)])
         for dd in env.exclusions["r1"]
     ] == [
-        ("2025-01-31", "2025-04-01", "2025-03-02"),
-        ("2025-01-01", "2025-03-02", "2025-01-31"),
+        ("2025-02-01T06", "2025-04-01T06", "2025-03-02T18"),
+        ("2025-01-02T06", "2025-03-02T06", "2025-01-31T18"),
     ]
     assert [
-        tuple([d.strftime("%Y-%m-%d") for d in (dd.start, dd.end, dd.main_date)])
+        tuple([d.strftime("%Y-%m-%dT%H") for d in (dd.start, dd.end, dd.main_date)])
         for dd in env.clearance_exclusions["C1"]
     ] == [
-        ("2025-02-23", "2025-03-09", "2025-03-02"),
-        ("2025-01-24", "2025-02-07", "2025-01-31"),
+        ("2025-02-24T06", "2025-03-09T06", "2025-03-02T18"),
+        ("2025-01-25T06", "2025-02-07T06", "2025-01-31T18"),
     ]
 
 

--- a/protohaven_api/commands/forwarding.py
+++ b/protohaven_api/commands/forwarding.py
@@ -142,17 +142,16 @@ class Commands:
         num = 0
         reqs = []
         now = tznow()
-        for c in airtable.get_class_automation_schedule():
-            d = safe_parse_datetime(c["fields"]["Start Time"])
-            if d < now or c["fields"]["Supply State"] != "Supplies Requested":
+        for c in airtable.get_class_automation_schedule(raw=False):
+            if c.start_time < now or c.supply_state != "Supplies Requested":
                 continue
 
             reqs.append(
                 {
-                    "days": (d - now).days,
-                    "name": ", ".join(c["fields"]["Name (from Class)"]),
-                    "date": d.strftime("%Y-%m-%d"),
-                    "inst": c["fields"]["Instructor"],
+                    "days": (c.start_time - now).days,
+                    "name": c.name,
+                    "date": c.start_time.strftime("%Y-%m-%d"),
+                    "inst": c.instructor_name,
                 }
             )
             log.info(str(reqs[-1]))

--- a/protohaven_api/commands/forwarding_test.py
+++ b/protohaven_api/commands/forwarding_test.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 import pytest
 
 from protohaven_api.commands import forwarding as F
+from protohaven_api.integrations.airtable import ScheduledClass
 from protohaven_api.testing import MatchStr, d, idfn, mkcli, t
 
 
@@ -338,25 +339,30 @@ def test_supply_requests(mocker, cli):
         F.airtable,
         "get_class_automation_schedule",
         return_value=[
-            {"fields": f}
-            for f in [
-                {
-                    # Confirmed, so not listed
-                    "Supply State": "Supplies Confirmed",
-                    "Start Time": d(1).isoformat(),
-                },
-                {
-                    # Already happened, so not listed
-                    "Supply State": "Supplies Requested",
-                    "Start Time": d(-1).isoformat(),
-                },
-                {
-                    "Supply State": "Supplies Requested",
-                    "Start Time": d(1).isoformat(),
-                    "Instructor": "Inst",
-                    "Name (from Class)": ["Classname"],
-                },
-            ]
+            ScheduledClass.from_schedule({"id": str(i), "fields": f})
+            for i, f in enumerate(
+                [
+                    {
+                        # Confirmed, so not listed
+                        "Supply State": "Supplies Confirmed",
+                        "Sessions": d(1).isoformat(),
+                        "Hours (from Class)": 3,
+                    },
+                    {
+                        # Already happened, so not listed
+                        "Supply State": "Supplies Requested",
+                        "Sessions": d(-1).isoformat(),
+                        "Hours (from Class)": 3,
+                    },
+                    {
+                        "Supply State": "Supplies Requested",
+                        "Sessions": d(1).isoformat(),
+                        "Hours (from Class)": 3,
+                        "Instructor": "Inst",
+                        "Name (from Class)": ["Classname"],
+                    },
+                ]
+            )
         ],
     )
     assert cli("supply_requests", []) == [

--- a/protohaven_api/handlers/instructor.py
+++ b/protohaven_api/handlers/instructor.py
@@ -282,7 +282,7 @@ def instructor_class_supply_req():
     """Mark supplies as missing or confirmed for a class"""
     data = request.json
     eid = data["eid"]
-    c = airtable.get_scheduled_class(eid, raw=False)
+    c = airtable.get_scheduled_class(eid)
     if not c:
         raise RuntimeError(f"Not found: class {eid}")
 
@@ -449,7 +449,7 @@ def class_neon_state():
 def cancel_class():
     """Cancel a class - fails if anyone is registered for it"""
     data = request.json
-    c = airtable.get_scheduled_class(data["class_id"], raw=False)
+    c = airtable.get_scheduled_class(data["class_id"])
     if not c:
         return Response("Not found", status=404)
 

--- a/protohaven_api/handlers/instructor_test.py
+++ b/protohaven_api/handlers/instructor_test.py
@@ -294,9 +294,7 @@ def test_instructor_class_supply_req(mocker, inst_client):
     )
 
     assert response.status_code == 200
-    instructor.airtable.get_scheduled_class.assert_called_once_with(
-        "class123", raw=False
-    )
+    instructor.airtable.get_scheduled_class.assert_called_once_with("class123")
     instructor.airtable.mark_schedule_supply_request.assert_called_once_with(
         "class123", "Supplies Requested"
     )

--- a/protohaven_api/handlers/staff.py
+++ b/protohaven_api/handlers/staff.py
@@ -76,12 +76,19 @@ def summarizer_ws(ws):
                     }
                 )
             )
-        summary = gpt.summarize_message_history(
-            [f"{m['created_at']} {m['author']}: {m['content']}" for m in msgs]
-        )
+        if len(msgs) < 5:
+            summary = "Too few messages to summarize this channel (want 5+)"
+        else:
+            summary = gpt.summarize_message_history(
+                [f"{m['created_at']} {m['author']}: {m['content']}" for m in msgs]
+            )
         ws.send(
             json.dumps(
-                {"type": "channel_summary", "channel": channel_name, "content": summary}
+                {
+                    "type": "channel_summary",
+                    "channel": channel_name,
+                    "content": summary,
+                }
             )
         )
         summaries.append((channel_name, summary))

--- a/protohaven_api/integrations/airtable.py
+++ b/protohaven_api/integrations/airtable.py
@@ -294,19 +294,17 @@ def _unwrap(row, field):
     return v
 
 
-def get_class_automation_schedule(include_rejected=True, raw=True):
+def get_class_automation_schedule(include_rejected=True, raw=False):
     """Grab the current automated class schedule"""
     for row in get_all_records("class_automation", "schedule"):
         if not row["fields"].get("Rejected") or include_rejected:
             yield (row if raw else ScheduledClass.from_schedule(row))
 
 
-def get_scheduled_class(rec, raw=True):
+def get_scheduled_class(rec):
     """Get the specific scheduled class row by reference"""
     result = get_record("class_automation", "schedule", rec)
-    if result and not raw:
-        return ScheduledClass.from_schedule(result)
-    return result
+    return ScheduledClass.from_schedule(result)
 
 
 def get_notifications_after(tag, after_date):
@@ -462,7 +460,7 @@ def respond_class_automation_schedule(eid: RecordID, pub: bool) -> ScheduledClas
     status, result = update_record(data, "class_automation", "schedule", eid)
     if status != 200:
         raise RuntimeError(f"Error updating class schedule state for {eid}: {result}")
-    return get_scheduled_class(eid, raw=False)
+    return get_scheduled_class(eid)
 
 
 def apply_violation_accrual(vid, accrued):
@@ -490,7 +488,7 @@ def mark_schedule_supply_request(eid: RecordID, state) -> ScheduledClass:
     )
     if status != 200:
         raise RuntimeError(f"Error setting supply state for {eid}: {result}")
-    return get_scheduled_class(eid, raw=False)
+    return get_scheduled_class(eid)
 
 
 def mark_schedule_volunteer(eid: RecordID, volunteer: bool) -> ScheduledClass:
@@ -500,7 +498,7 @@ def mark_schedule_volunteer(eid: RecordID, volunteer: bool) -> ScheduledClass:
     )
     if status != 200:
         raise RuntimeError(f"Error setting volunteer status for {eid}: {result}")
-    return get_scheduled_class(eid, raw=False)
+    return get_scheduled_class(eid)
 
 
 def get_tools():

--- a/protohaven_api/integrations/sheets.py
+++ b/protohaven_api/integrations/sheets.py
@@ -75,7 +75,8 @@ def get_passing_student_clearances(
 
         tool_codes = sub.get(TOOLS_HDR)
         tool_codes = (
-            [s.split(":")[0].strip() for s in tool_codes.split(",")]
+            # Handle e.g. "Welding - WGR: Tungsten Grinder" -> "WGR"
+            [s.split(":")[0].split(" ")[-1].strip() for s in tool_codes.split(",")]
             if tool_codes
             else None
         )

--- a/protohaven_api/integrations/sheets_test.py
+++ b/protohaven_api/integrations/sheets_test.py
@@ -205,13 +205,18 @@ def test_get_passing_student_clearances(mocker):
     now = str(datetime.datetime.now(tz=tz))
     data[sheet_id]["Form Responses 1"] = [
         ["Timestamp", s.PASS_HDR, s.CLEARANCE_HDR, s.TOOLS_HDR],
-        [now, "foo@gmail.com", "123:code,456:code", "band_saw:tool,welder:tool"],
+        [
+            now,
+            "foo@gmail.com",
+            "123:code,456:code",
+            "band_saw:tool,welder:tool,area TC: tool",
+        ],
     ]
     install_fake_sheets_service(s, mocker, data)
 
     expected = (
         "foo@gmail.com",
-        ["band_saw", "welder"],
+        ["band_saw", "welder", "TC"],
         safe_parse_datetime(now),
     )
 

--- a/svelte/src/lib/instructor/class_card.svelte
+++ b/svelte/src/lib/instructor/class_card.svelte
@@ -185,7 +185,9 @@ function cancel(class_id) {
     {/if}
   </li>
   <li>Instruction: {#if c.volunteer}Volunteer (no pay){:else}Paid{/if} </li>
-  <li>Instructor confirmed:  {#if c.confirmed}on {new Date(c.confirmed).toLocaleString()}{:else}no{/if}</li>
+  {#if c.confirmed}
+    <li>Proposed {new Date(c.confirmed).toLocaleString()}</li>
+  {/if}
   </ul>
 
   {#if c.neon_id}
@@ -245,11 +247,6 @@ function cancel(class_id) {
 
 
       {#if !c.neon_id}
-	{#if c.confirmed}
-	<DropdownItem on:click={() => confirm(null)}>Unconfirm</DropdownItem>
-	{:else}
-        <DropdownItem on:click={() => confirm(true)}>Confirm available</DropdownItem>
-	{/if}
 	<DropdownItem divider />
         <DropdownItem on:click={() => confirm(false)}>Mark unavailable (hides permanently)</DropdownItem>
       {:else}

--- a/svelte/src/lib/instructor/scheduler.svelte
+++ b/svelte/src/lib/instructor/scheduler.svelte
@@ -32,8 +32,8 @@
 
   function candidate_times(session_duration) {
     let times = [];
-    const MAX_HR = (admin) ? 24 : 22 - session_duration; // 10pm is close
-    const MIN_HR = (admin) ? 0 : 10; // 10am is open
+    const MAX_HR = 24;
+    const MIN_HR = 0;
     for (let hour = MIN_HR; hour <= MAX_HR; hour++) { // 10am is open
       for (let minute of (hour < MAX_HR) ? [0, 30] : [0]) {
         const h = hour.toString().padStart(2, '0');

--- a/svelte/src/lib/techs/storage.svelte
+++ b/svelte/src/lib/techs/storage.svelte
@@ -161,7 +161,7 @@ $: {
 <CardSubtitle>View active subscriptions and add details*</CardSubtitle>
 </CardHeader>
 <CardBody>
-    <div class="my-2"><em>*Non-Square storage agreements are only editable via Airtable - see People > Storage Agreements</em></div>
+    <div class="my-2"><em>*Non-Square storage agreements are editable <a href="https://airtable.com/appZIwlIgaq1Ps28Y/tblFoG5HKnRfuZsD7/viw3tzhfEh5trfBuH?blocks=hide" target="_blank">on Airtable</a></em></div>
     {#if sub_note_editing}
       <Spinner/> {sub_fetch_status}
     {/if}

--- a/svelte/src/routes/instructor/+page.svelte
+++ b/svelte/src/routes/instructor/+page.svelte
@@ -28,12 +28,24 @@ onMount(() => {
   const urlParams = new URLSearchParams(window.location.search);
   let e = urlParams.get("email");
   console.log(`E is ${e}; fetching /whoami`);
+  try {
+    // Initial /whoami takes time to fetch and delays page interaction,
+    // so we serve a cached version before the request completes.
+    const cached = JSON.parse(localStorage.getItem("whoami_cache"));
+    if (cached) {
+      user = cached.user;
+      admin = cached.admin;
+    }
+  }
 	promise = get("/whoami").then((d) => {
+      console.log(d);
       admin = (d.roles || []).some(role =>
         ["Tech Lead", "Education Lead", "Admin", "Board Member", "Staff"].includes(role)
       );
-      console.log(d)
       user=d;
+      try {
+        localStorage.setItem("whoami_cache", JSON.stringify({admin, user});
+      }
       if (!e) {
         promise = Promise.resolve(d);
         fetch_instructor_profile(d.email);

--- a/svelte/src/routes/techs/+page.svelte
+++ b/svelte/src/routes/techs/+page.svelte
@@ -57,6 +57,9 @@
       <NavLink href="https://protohaven.org/maintenance" target="_blank">Tool Report</NavLink>
     </NavItem>
     <NavItem>
+      <NavLink href="https://protohaven.org/injury" target="_blank">Injury Report</NavLink>
+    </NavItem>
+    <NavItem>
       <NavLink href="https://wiki.protohaven.org/shelves/shop-techs" target="_blank">Wiki</NavLink>
     </NavItem>
     <NavItem>


### PR DESCRIPTION
* Support "Event ID" rename in Scheduler airtable
* Add 12hr wiggle room to period when scheduling classes
* Remove "raw" return option for `get_scheduled_class`
* Prevent Discord summarizer from running on <5 messages
* Move away from instructor confirm/unconfirm in favor of "Mark unavailable"
* Allow instructors scheduling before open / after close (validation blocks)
* Add airtable link for non-Square subscription tracking
* Cache initial /whoami call in instructor dashboard
* Add injury report link to tech dashboard