### PR TITLE
Neon cache server implementation

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,49 @@
 services:
+  account_cache:
+    build:
+      context: .
+      dockerfile: protohaven_api.Dockerfile
+    container_name: protohaven_api_account_cache
+    ports:
+      - "5001:5001"
+    command: "/usr/local/bin/python3 -m protohaven_api.cache_server"
+    environment:
+      CORS: true
+      LOG_LEVEL: "debug"
+      PH_CONFIG: "config.yaml"
+      PH_SERVER_MODE: "dev"
+      NOCODB_HOST: "nocodb_frontend"
+      NOCODB_PORT: "8080" # Note: we're using the internal port since we're operating inside the docker network
+    configs:
+      - source: ph-config
+        target: /config.yaml
+    depends_on:
+      nocodb_frontend:
+        condition: service_healthy
+    develop:
+      watch:
+        - action: sync+restart
+          path: .
+          ignore:
+            - .devenv
+            - .direnv
+            - .git
+            - requirements.txt
+            - Dockerfile
+            - svelte
+            - bookstack
+            - wordpress
+            - docs
+          target: /code
+        - action: rebuild
+          path: requirements.txt
+        - action: rebuild
+          path: protohaven_api.Dockerfile
+    healthcheck:
+      interval: 10s
+      retries: 10
+      test: "curl localhost:5000"
+      timeout: 2s
   flask:
     build:
       context: .

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,10 @@ general:
   precache_sign_in: ${PRECACHE_SIGN_IN}
   external_access_codes:
     ${EXTERNAL_ACCESS_CODES_AUTOMATION}: ["Automation"]
+cache_server:
+  enabled: false
+  port: 5001
+  base_url: "http://localhost:5001"
   class_scheduling:
     clearance_exclusion_range_days: 7
   unsafe:

--- a/config.yaml
+++ b/config.yaml
@@ -11,10 +11,6 @@ general:
   precache_sign_in: ${PRECACHE_SIGN_IN}
   external_access_codes:
     ${EXTERNAL_ACCESS_CODES_AUTOMATION}: ["Automation"]
-cache_server:
-  enabled: false
-  port: 5001
-  base_url: "http://localhost:5001"
   class_scheduling:
     clearance_exclusion_range_days: 7
   unsafe:
@@ -39,6 +35,10 @@ cache_server:
   new_membership:
     # Either "eventbrite" or "neon"
     discount_type: ${NEW_MEMBERSHIP_DISCOUNT_TYPE}
+cache_server:
+  enabled: ${CACHE_SERVER_ENABLED}
+  port: 5001
+  base_url: ${CACHE_SERVER_BASE_URL}
 cronicle:
   # Used as a base for links to execution log when
   # CLI commands are issued via Cronicle

--- a/protohaven_api.Dockerfile
+++ b/protohaven_api.Dockerfile
@@ -24,6 +24,6 @@ RUN pip install  -r requirements.txt
 RUN pip install flask-sock playwright
 RUN playwright install --with-deps --only-shell firefox
 
-EXPOSE 5000
+# EXPOSE 5000
 COPY . .
 CMD ["flask", "run", "--debug"]

--- a/protohaven_api/automation/membership/sign_in.py
+++ b/protohaven_api/automation/membership/sign_in.py
@@ -154,7 +154,7 @@ def get_member_and_activation_state(email):
     https://docs.google.com/document/d/1O8qsvyWyVF7qY0cBQTNUcT60DdfMaLGg8FUDQdciivM/edit?usp=sharing
     """
     # Only select individuals as members, not companies
-    mm = (neon.cache.get(email) or {}).values()
+    mm = (neon.cached_get(email) or {}).values()
     mm = [m for m in mm if m.neon_id != m.company_id]
     if len(mm) == 0:
         return None, False

--- a/protohaven_api/automation/techs/techs.py
+++ b/protohaven_api/automation/techs/techs.py
@@ -98,7 +98,7 @@ def resolve_overrides(
     for p in ovr_people_in:
         p = re.sub(r"\(.*\)", "", p)  # remove pronouns for matching purposes
         p = re.sub(r" +", " ", p)  # prevent double-space issues
-        mm = list(neon.cache.find_best_match(p))
+        mm = list(neon.cached_find_best_match(p))
         found = False
         log.info(f"Seeking match for tech override {p}")
         for m in mm:

--- a/protohaven_api/cache_server.py
+++ b/protohaven_api/cache_server.py
@@ -6,6 +6,7 @@ independently from the main Flask application.
 
 Endpoints:
   GET /find_best_match?search=...&top_n=10&score_cutoff=65
+  GET /neon_id_from_booked_id?booked_id=<int>
   GET /get?key=<email>
 
 Usage:
@@ -86,6 +87,25 @@ def create_app() -> Flask:
             results.append(_serialize_member(member))
 
         return jsonify(results)
+
+    @fapp.route("/neon_id_from_booked_id")
+    def neon_id_from_booked_id() -> tuple[Response, int] | Response:
+        """Look up the Neon ID associated with a Booked scheduler user ID.
+
+        Query params:
+            booked_id: The Booked scheduler user ID (required, integer)
+        """
+        booked_id_str: str = request.args.get("booked_id", "")
+        if not booked_id_str:
+            return jsonify({"error": "booked_id parameter is required"}), 400
+
+        try:
+            booked_id: int = int(booked_id_str)
+        except ValueError:
+            return jsonify({"error": "booked_id must be an integer"}), 400
+
+        neon_id: str = neon.cache.neon_id_from_booked_id(booked_id)
+        return jsonify({"neon_id": neon_id})
 
     @fapp.route("/get")
     def get_member() -> tuple[Response, int] | Response:

--- a/protohaven_api/cache_server.py
+++ b/protohaven_api/cache_server.py
@@ -137,6 +137,8 @@ def create_app() -> Flask:
 if __name__ == "__main__":
     logging.basicConfig(level=get_config("general/log_level", "INFO").upper())
     application: Flask = create_app()
-    port: int = int(get_config("cache_server/port", 5001))  # pylint: disable=invalid-name
+    port: int = int(
+        get_config("cache_server/port", 5001)
+    )  # pylint: disable=invalid-name
     log.info("Starting cache server on port %s", port)
     application.run(host="0.0.0.0", port=port)

--- a/protohaven_api/cache_server.py
+++ b/protohaven_api/cache_server.py
@@ -1,0 +1,119 @@
+"""
+Standalone Flask server exposing AccountCache methods over HTTP.
+
+Intended to be run as a separate process so caching can be scaled
+independently from the main Flask application.
+
+Endpoints:
+  GET /find_best_match?search=...&top_n=10&score_cutoff=65
+  GET /get?key=<email>
+
+Usage:
+  python -m protohaven_api.cache_server
+  gunicorn protohaven_api.cache_server:app
+"""
+
+import logging
+
+from flask import Flask, jsonify, request
+
+from protohaven_api.config import get_config
+from protohaven_api.integrations import neon
+from protohaven_api.integrations.data.connector import Connector
+from protohaven_api.integrations.data.connector import init as init_connector
+
+log = logging.getLogger("cache_server")
+
+# Module-level app for gunicorn (created lazily so tests can mock first)
+app = None  # pylint: disable=invalid-name
+
+
+def _serialize_member(member):
+    """Serialize a Member object to a JSON-compatible dict.
+
+    Uses neon_search_data as the primary source since that is what
+    AccountCache stores after refresh. Falls back to computed properties
+    where needed.
+    """
+    return {
+        "neon_id": member.neon_id,
+        "fname": member.fname,
+        "lname": member.lname,
+        "email": member.email,
+        "name": member.name,
+        "account_current_membership_status": (
+            member.account_current_membership_status
+        ),
+        "membership_level": member.membership_level,
+        "neon_search_data": member.neon_search_data,
+    }
+
+
+def create_app():
+    """Create and configure the cache server Flask app.
+
+    Also sets the module-level `app` for gunicorn compatibility.
+    """
+    global app  # pylint: disable=global-statement
+
+    fapp = Flask(__name__)
+
+    # Initialize connector so AccountCache can make Neon API calls on cache miss
+    init_connector(Connector)
+    neon.cache.start()
+    log.info("AccountCache started for cache_server")
+
+    @fapp.route("/find_best_match")
+    def find_best_match():
+        """Fuzzy-search for members by name/email.
+
+        Query params:
+            search: The search string (required)
+            top_n: Max results to return (default 10)
+            score_cutoff: Minimum fuzzy match score 0-100 (default 65)
+        """
+        search = request.args.get("search", "")
+        if not search:
+            return jsonify({"error": "search parameter is required"}), 400
+
+        top_n = int(request.args.get("top_n", 10))
+        score_cutoff = int(request.args.get("score_cutoff", 65))
+
+        results = []
+        for member in neon.cache.find_best_match(
+            search, top_n=top_n, score_cutoff=score_cutoff
+        ):
+            results.append(_serialize_member(member))
+
+        return jsonify(results)
+
+    @fapp.route("/get")
+    def get_member():
+        """Look up members by email.
+
+        Query params:
+            key: The email address to look up (required)
+        """
+        key = request.args.get("key", "")
+        if not key:
+            return jsonify({"error": "key parameter is required"}), 400
+
+        data = neon.cache.get(key, {})
+        result = {}
+        for neon_id, member in data.items():
+            result[neon_id] = _serialize_member(member)
+
+        return jsonify(result)
+
+    app = fapp
+    return fapp
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=get_config("general/log_level", "INFO").upper()
+    )
+    application = create_app()
+    port = int(get_config("cache_server/port", 5001))  # pylint: disable=invalid-name
+    log.info("Starting cache server on port %s", port)
+    application.run(host="0.0.0.0", port=port)

--- a/protohaven_api/cache_server.py
+++ b/protohaven_api/cache_server.py
@@ -21,8 +21,11 @@ from protohaven_api.config import get_config
 from protohaven_api.integrations import neon
 from protohaven_api.integrations.data.connector import Connector
 from protohaven_api.integrations.data.connector import init as init_connector
+from protohaven_api.integrations.data.dev_connector import DevConnector
 
 log = logging.getLogger("cache_server")
+
+server_mode = get_config("general/server_mode").lower()
 
 # Module-level app for gunicorn (created lazily so tests can mock first)
 app = None  # pylint: disable=invalid-name
@@ -41,9 +44,7 @@ def _serialize_member(member):
         "lname": member.lname,
         "email": member.email,
         "name": member.name,
-        "account_current_membership_status": (
-            member.account_current_membership_status
-        ),
+        "account_current_membership_status": (member.account_current_membership_status),
         "membership_level": member.membership_level,
         "neon_search_data": member.neon_search_data,
     }
@@ -59,7 +60,8 @@ def create_app():
     fapp = Flask(__name__)
 
     # Initialize connector so AccountCache can make Neon API calls on cache miss
-    init_connector(Connector)
+    log.info(f"Initializing connector ({server_mode})")
+    init_connector(Connector if server_mode == "prod" else DevConnector)
     neon.cache.start()
     log.info("AccountCache started for cache_server")
 
@@ -110,9 +112,7 @@ def create_app():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=get_config("general/log_level", "INFO").upper()
-    )
+    logging.basicConfig(level=get_config("general/log_level", "INFO").upper())
     application = create_app()
     port = int(get_config("cache_server/port", 5001))  # pylint: disable=invalid-name
     log.info("Starting cache server on port %s", port)

--- a/protohaven_api/cache_server.py
+++ b/protohaven_api/cache_server.py
@@ -14,59 +14,57 @@ Usage:
 """
 
 import logging
+from typing import Any, Dict, Optional
 
-from flask import Flask, jsonify, request
+from flask import Flask, Response, jsonify, request
 
 from protohaven_api.config import get_config
 from protohaven_api.integrations import neon
 from protohaven_api.integrations.data.connector import Connector
 from protohaven_api.integrations.data.connector import init as init_connector
 from protohaven_api.integrations.data.dev_connector import DevConnector
+from protohaven_api.integrations.models import Member
 
 log = logging.getLogger("cache_server")
 
-server_mode = get_config("general/server_mode").lower()
+server_mode: str = get_config("general/server_mode").lower()
 
 # Module-level app for gunicorn (created lazily so tests can mock first)
-app = None  # pylint: disable=invalid-name
+app: Optional[Flask] = None  # pylint: disable=invalid-name
 
 
-def _serialize_member(member):
-    """Serialize a Member object to a JSON-compatible dict.
+def _serialize_member(member: Member) -> Dict[str, Any]:
+    """Serialize a Member object to its raw dataclass fields.
 
-    Uses neon_search_data as the primary source since that is what
-    AccountCache stores after refresh. Falls back to computed properties
-    where needed.
+    Returns the underlying dataclass fields (neon_raw_data, neon_search_data,
+    neon_membership_data, airtable_bio_data) so the Member can be fully
+    reconstructed on the client side via Member(**data).
     """
     return {
-        "neon_id": member.neon_id,
-        "fname": member.fname,
-        "lname": member.lname,
-        "email": member.email,
-        "name": member.name,
-        "account_current_membership_status": (member.account_current_membership_status),
-        "membership_level": member.membership_level,
+        "neon_raw_data": member.neon_raw_data,
         "neon_search_data": member.neon_search_data,
+        "neon_membership_data": member.neon_membership_data,
+        "airtable_bio_data": member.airtable_bio_data,
     }
 
 
-def create_app():
+def create_app() -> Flask:
     """Create and configure the cache server Flask app.
 
     Also sets the module-level `app` for gunicorn compatibility.
     """
     global app  # pylint: disable=global-statement
 
-    fapp = Flask(__name__)
+    fapp: Flask = Flask(__name__)
 
     # Initialize connector so AccountCache can make Neon API calls on cache miss
-    log.info(f"Initializing connector ({server_mode})")
+    log.info("Initializing connector (%s)", server_mode)
     init_connector(Connector if server_mode == "prod" else DevConnector)
     neon.cache.start()
     log.info("AccountCache started for cache_server")
 
     @fapp.route("/find_best_match")
-    def find_best_match():
+    def find_best_match() -> tuple[Response, int] | Response:
         """Fuzzy-search for members by name/email.
 
         Query params:
@@ -74,14 +72,14 @@ def create_app():
             top_n: Max results to return (default 10)
             score_cutoff: Minimum fuzzy match score 0-100 (default 65)
         """
-        search = request.args.get("search", "")
+        search: str = request.args.get("search", "")
         if not search:
             return jsonify({"error": "search parameter is required"}), 400
 
-        top_n = int(request.args.get("top_n", 10))
-        score_cutoff = int(request.args.get("score_cutoff", 65))
+        top_n: int = int(request.args.get("top_n", 10))
+        score_cutoff: int = int(request.args.get("score_cutoff", 65))
 
-        results = []
+        results: list[Dict[str, Any]] = []
         for member in neon.cache.find_best_match(
             search, top_n=top_n, score_cutoff=score_cutoff
         ):
@@ -90,18 +88,23 @@ def create_app():
         return jsonify(results)
 
     @fapp.route("/get")
-    def get_member():
+    def get_member() -> tuple[Response, int] | Response:
         """Look up members by email.
 
         Query params:
             key: The email address to look up (required)
+            fetch_if_missing: Whether to fall back to Neon API on cache miss
+                              (default "1", set to "0" to disable)
         """
-        key = request.args.get("key", "")
+        key: str = request.args.get("key", "")
         if not key:
             return jsonify({"error": "key parameter is required"}), 400
 
-        data = neon.cache.get(key, {})
-        result = {}
+        fetch_if_missing: bool = request.args.get("fetch_if_missing", "1") != "0"
+        data: Dict[str, Member] = neon.cache.get(
+            key, {}, fetch_if_missing=fetch_if_missing
+        )
+        result: Dict[str, Dict[str, Any]] = {}
         for neon_id, member in data.items():
             result[neon_id] = _serialize_member(member)
 
@@ -113,7 +116,7 @@ def create_app():
 
 if __name__ == "__main__":
     logging.basicConfig(level=get_config("general/log_level", "INFO").upper())
-    application = create_app()
-    port = int(get_config("cache_server/port", 5001))  # pylint: disable=invalid-name
+    application: Flask = create_app()
+    port: int = int(get_config("cache_server/port", 5001))  # pylint: disable=invalid-name
     log.info("Starting cache server on port %s", port)
     application.run(host="0.0.0.0", port=port)

--- a/protohaven_api/cache_server_test.py
+++ b/protohaven_api/cache_server_test.py
@@ -18,9 +18,16 @@ def fixture_client(mocker):
     return fapp.test_client()
 
 
-def _mock_member(mocker, neon_id="123", fname="Alice", lname="Anderson",
-                 email="alice@example.com", name="Alice Anderson",
-                 status="Active", level="General Membership"):
+def _mock_member(
+    mocker,
+    neon_id="123",
+    fname="Alice",
+    lname="Anderson",
+    email="alice@example.com",
+    name="Alice Anderson",
+    status="Active",
+    level="General Membership",
+):
     """Create a mock Member with the given properties."""
     m = mocker.MagicMock()
     m.neon_id = neon_id

--- a/protohaven_api/cache_server_test.py
+++ b/protohaven_api/cache_server_test.py
@@ -1,0 +1,143 @@
+"""Tests for the standalone cache server."""
+
+# pylint: skip-file
+import json
+
+import pytest
+
+from protohaven_api import cache_server
+
+
+@pytest.fixture(name="client")
+def fixture_client(mocker):
+    """Create a test client that mocks out neon.cache and connector init."""
+    mocker.patch.object(cache_server, "init_connector")
+    mocker.patch.object(cache_server.neon.cache, "start")
+
+    fapp = cache_server.create_app()
+    return fapp.test_client()
+
+
+def _mock_member(mocker, neon_id="123", fname="Alice", lname="Anderson",
+                 email="alice@example.com", name="Alice Anderson",
+                 status="Active", level="General Membership"):
+    """Create a mock Member with the given properties."""
+    m = mocker.MagicMock()
+    m.neon_id = neon_id
+    m.fname = fname
+    m.lname = lname
+    m.email = email
+    m.name = name
+    m.account_current_membership_status = status
+    m.membership_level = level
+    m.neon_search_data = {
+        "Account ID": neon_id,
+        "First Name": fname,
+        "Last Name": lname,
+        "Email 1": email,
+        "Account Current Membership Status": status,
+        "Membership Level": level,
+    }
+    return m
+
+
+def test_find_best_match_no_search_param(client):
+    """find_best_match returns 400 when search is missing."""
+    resp = client.get("/find_best_match")
+    assert resp.status_code == 400
+    assert json.loads(resp.data) == {"error": "search parameter is required"}
+
+
+def test_find_best_match_returns_serialized_members(mocker, client):
+    """find_best_match calls neon.cache.find_best_match and serializes results."""
+    member = _mock_member(mocker)
+    mocker.patch.object(
+        cache_server.neon.cache,
+        "find_best_match",
+        return_value=[member],
+    )
+
+    resp = client.get("/find_best_match?search=Alice")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert len(data) == 1
+    assert data[0]["neon_id"] == "123"
+    assert data[0]["fname"] == "Alice"
+    assert data[0]["email"] == "alice@example.com"
+    assert data[0]["account_current_membership_status"] == "Active"
+
+
+def test_find_best_match_passes_params(mocker, client):
+    """find_best_match passes top_n and score_cutoff through to cache."""
+    mocker.patch.object(
+        cache_server.neon.cache,
+        "find_best_match",
+        return_value=[],
+    )
+
+    client.get("/find_best_match?search=Bob&top_n=5&score_cutoff=80")
+    cache_server.neon.cache.find_best_match.assert_called_with(
+        "Bob", top_n=5, score_cutoff=80
+    )
+
+
+def test_get_no_key_param(client):
+    """get returns 400 when key is missing."""
+    resp = client.get("/get")
+    assert resp.status_code == 400
+    assert json.loads(resp.data) == {"error": "key parameter is required"}
+
+
+def test_get_returns_serialized_members(mocker, client):
+    """get calls neon.cache.get and serializes result dict."""
+    member = _mock_member(mocker)
+    mocker.patch.object(
+        cache_server.neon.cache,
+        "get",
+        return_value={"123": member},
+    )
+
+    resp = client.get("/get?key=alice@example.com")
+    assert resp.status_code == 200
+    data = json.loads(resp.data)
+    assert "123" in data
+    assert data["123"]["neon_id"] == "123"
+    assert data["123"]["email"] == "alice@example.com"
+
+
+def test_get_empty_result(mocker, client):
+    """get returns empty dict when cache returns nothing."""
+    mocker.patch.object(
+        cache_server.neon.cache,
+        "get",
+        return_value={},
+    )
+
+    resp = client.get("/get?key=nonexistent@example.com")
+    assert resp.status_code == 200
+    assert json.loads(resp.data) == {}
+
+
+def test_serialize_member(mocker):
+    """_serialize_member extracts the right fields from a Member."""
+    member = _mock_member(
+        mocker,
+        neon_id="456",
+        fname="Bob",
+        lname="Builder",
+        email="bob@example.com",
+        name="Bob Builder",
+        status="Future",
+        level="Weekend Membership",
+    )
+    result = cache_server._serialize_member(member)
+    assert result == {
+        "neon_id": "456",
+        "fname": "Bob",
+        "lname": "Builder",
+        "email": "bob@example.com",
+        "name": "Bob Builder",
+        "account_current_membership_status": "Future",
+        "membership_level": "Weekend Membership",
+        "neon_search_data": member.neon_search_data,
+    }

--- a/protohaven_api/cache_server_test.py
+++ b/protohaven_api/cache_server_test.py
@@ -38,7 +38,24 @@ def _mock_member(mocker, neon_id="123", fname="Alice", lname="Anderson",
         "Account Current Membership Status": status,
         "Membership Level": level,
     }
+    m.neon_raw_data = {}
+    m.neon_membership_data = None
+    m.airtable_bio_data = {}
     return m
+
+
+def _expected_serialized(member):
+    """Build expected dict that asdict would produce from a mock Member.
+
+    Since mock objects don't work with dataclasses.asdict, we define the
+    expected output manually to match the Member dataclass fields.
+    """
+    return {
+        "neon_raw_data": member.neon_raw_data,
+        "neon_search_data": member.neon_search_data,
+        "neon_membership_data": member.neon_membership_data,
+        "airtable_bio_data": member.airtable_bio_data,
+    }
 
 
 def test_find_best_match_no_search_param(client):
@@ -61,10 +78,7 @@ def test_find_best_match_returns_serialized_members(mocker, client):
     assert resp.status_code == 200
     data = json.loads(resp.data)
     assert len(data) == 1
-    assert data[0]["neon_id"] == "123"
-    assert data[0]["fname"] == "Alice"
-    assert data[0]["email"] == "alice@example.com"
-    assert data[0]["account_current_membership_status"] == "Active"
+    assert data[0] == _expected_serialized(member)
 
 
 def test_find_best_match_passes_params(mocker, client):
@@ -101,8 +115,7 @@ def test_get_returns_serialized_members(mocker, client):
     assert resp.status_code == 200
     data = json.loads(resp.data)
     assert "123" in data
-    assert data["123"]["neon_id"] == "123"
-    assert data["123"]["email"] == "alice@example.com"
+    assert data["123"] == _expected_serialized(member)
 
 
 def test_get_empty_result(mocker, client):
@@ -116,28 +129,3 @@ def test_get_empty_result(mocker, client):
     resp = client.get("/get?key=nonexistent@example.com")
     assert resp.status_code == 200
     assert json.loads(resp.data) == {}
-
-
-def test_serialize_member(mocker):
-    """_serialize_member extracts the right fields from a Member."""
-    member = _mock_member(
-        mocker,
-        neon_id="456",
-        fname="Bob",
-        lname="Builder",
-        email="bob@example.com",
-        name="Bob Builder",
-        status="Future",
-        level="Weekend Membership",
-    )
-    result = cache_server._serialize_member(member)
-    assert result == {
-        "neon_id": "456",
-        "fname": "Bob",
-        "lname": "Builder",
-        "email": "bob@example.com",
-        "name": "Bob Builder",
-        "account_current_membership_status": "Future",
-        "membership_level": "Weekend Membership",
-        "neon_search_data": member.neon_search_data,
-    }

--- a/protohaven_api/cache_server_test.py
+++ b/protohaven_api/cache_server_test.py
@@ -118,6 +118,34 @@ def test_get_returns_serialized_members(mocker, client):
     assert data["123"] == _expected_serialized(member)
 
 
+def test_neon_id_from_booked_id_no_param(client):
+    """neon_id_from_booked_id returns 400 when booked_id is missing."""
+    resp = client.get("/neon_id_from_booked_id")
+    assert resp.status_code == 400
+    assert json.loads(resp.data) == {"error": "booked_id parameter is required"}
+
+
+def test_neon_id_from_booked_id_invalid_param(client):
+    """neon_id_from_booked_id returns 400 when booked_id is not an integer."""
+    resp = client.get("/neon_id_from_booked_id?booked_id=abc")
+    assert resp.status_code == 400
+    assert json.loads(resp.data) == {"error": "booked_id must be an integer"}
+
+
+def test_neon_id_from_booked_id_returns_neon_id(mocker, client):
+    """neon_id_from_booked_id calls cache and returns the neon_id."""
+    mocker.patch.object(
+        cache_server.neon.cache,
+        "neon_id_from_booked_id",
+        return_value="456",
+    )
+
+    resp = client.get("/neon_id_from_booked_id?booked_id=42")
+    assert resp.status_code == 200
+    assert json.loads(resp.data) == {"neon_id": "456"}
+    cache_server.neon.cache.neon_id_from_booked_id.assert_called_with(42)
+
+
 def test_get_empty_result(mocker, client):
     """get returns empty dict when cache returns nothing."""
     mocker.patch.object(

--- a/protohaven_api/handlers/index.py
+++ b/protohaven_api/handlers/index.py
@@ -159,7 +159,7 @@ def neon_id_lookup():
     if search is None:
         log.info("No search data provided")
         return result
-    for i in neon.cache.find_best_match(
+    for i in neon.cached_find_best_match(
         search, score_cutoff=int(request.values.get("min_score") or 65)
     ):
         result.append(

--- a/protohaven_api/handlers/techs.py
+++ b/protohaven_api/handlers/techs.py
@@ -722,7 +722,7 @@ def storage_sub_sock(ws):  # pylint: disable=too-many-locals
         # We avoid re-fetching if missing because neon is heckin' slow and it times out the request
         mem_statuses = [
             (m.account_current_membership_status or None)
-            for m in (neon.cache.get(cust_email, fetch_if_missing=False) or {}).values()
+            for m in (neon.cached_get(cust_email, fetch_if_missing=False) or {}).values()
             if m.neon_id != m.company_id
         ]
         status = "Unknown"

--- a/protohaven_api/handlers/techs.py
+++ b/protohaven_api/handlers/techs.py
@@ -722,7 +722,9 @@ def storage_sub_sock(ws):  # pylint: disable=too-many-locals
         # We avoid re-fetching if missing because neon is heckin' slow and it times out the request
         mem_statuses = [
             (m.account_current_membership_status or None)
-            for m in (neon.cached_get(cust_email, fetch_if_missing=False) or {}).values()
+            for m in (
+                neon.cached_get(cust_email, fetch_if_missing=False) or {}
+            ).values()
             if m.neon_id != m.company_id
         ]
         status = "Unknown"

--- a/protohaven_api/integrations/data/connector.py
+++ b/protohaven_api/integrations/data/connector.py
@@ -353,7 +353,7 @@ class Connector:  # pylint: disable=too-many-public-methods
         if r.status_code != 200:
             raise RuntimeError(
                 f"cache_server_request(endpoint={endpoint}, params={params}) "
-                f"returned {r.status_code}: {r.content}"
+                f"returned {r.status_code}: {r.content.decode('utf8')}"
             )
         return r.json()
 

--- a/protohaven_api/integrations/data/connector.py
+++ b/protohaven_api/integrations/data/connector.py
@@ -337,6 +337,26 @@ class Connector:  # pylint: disable=too-many-public-methods
             .execute()
         )
 
+    def cache_server_request(self, endpoint: str, params: dict) -> dict:
+        """Make a request to the cache server.
+
+        Args:
+            endpoint: The cache server endpoint path (e.g. "/find_best_match")
+            params: Query parameters to send with the request
+
+        Returns:
+            Parsed JSON response from the cache server
+        """
+        base_url: str = get_config("cache_server/base_url", "http://localhost:5001")
+        url: str = urljoin(base_url, endpoint.lstrip("/"))
+        r = requests.request("GET", url, params=params, timeout=self.timeout)
+        if r.status_code != 200:
+            raise RuntimeError(
+                f"cache_server_request(endpoint={endpoint}, params={params}) "
+                f"returned {r.status_code}: {r.content}"
+            )
+        return r.json()
+
 
 C = None
 

--- a/protohaven_api/integrations/data/connector_test.py
+++ b/protohaven_api/integrations/data/connector_test.py
@@ -230,3 +230,49 @@ def test_eventbrite_request(
     else:
         result = connector.eventbrite_request("GET", "/test")
         assert result == expected_result
+
+def test_cache_server_request(mocker):
+    """cache_server_request makes GET to cache server and returns JSON."""
+    mock_response = mocker.MagicMock(status_code=200)
+    mock_response.json.return_value = [{"a": 1}]
+    mocker.patch.object(con.requests, "request", return_value=mock_response)
+    mocker.patch.object(
+        con,
+        "get_config",
+        side_effect={
+            "cache_server/base_url": "http://localhost:5001",
+            "connector/timeout": 5.0,
+            "connector/num_attempts": 3,
+            "connector/max_retry_delay_sec": 1,
+        }.get,
+    )
+
+    connector = con.Connector()
+    result = connector.cache_server_request("/find_best_match", {"search": "Alice"})
+    assert result == [{"a": 1}]
+    con.requests.request.assert_called_with(
+        "GET",
+        "http://localhost:5001/find_best_match",
+        params={"search": "Alice"},
+        timeout=5.0,
+    )
+
+
+def test_cache_server_request_http_error(mocker):
+    """cache_server_request raises RuntimeError on non-200 response."""
+    mock_response = mocker.MagicMock(status_code=500, content="Server Error")
+    mocker.patch.object(con.requests, "request", return_value=mock_response)
+    mocker.patch.object(
+        con,
+        "get_config",
+        side_effect={
+            "cache_server/base_url": "http://localhost:5001",
+            "connector/timeout": 5.0,
+            "connector/num_attempts": 3,
+            "connector/max_retry_delay_sec": 1,
+        }.get,
+    )
+
+    connector = con.Connector()
+    with pytest.raises(RuntimeError, match="returned 500"):
+        connector.cache_server_request("/get", {"key": "foo"})

--- a/protohaven_api/integrations/data/connector_test.py
+++ b/protohaven_api/integrations/data/connector_test.py
@@ -260,7 +260,7 @@ def test_cache_server_request(mocker):
 
 def test_cache_server_request_http_error(mocker):
     """cache_server_request raises RuntimeError on non-200 response."""
-    mock_response = mocker.MagicMock(status_code=500, content="Server Error")
+    mock_response = mocker.MagicMock(status_code=500, content=b"Server Error")
     mocker.patch.object(con.requests, "request", return_value=mock_response)
     mocker.patch.object(
         con,

--- a/protohaven_api/integrations/data/connector_test.py
+++ b/protohaven_api/integrations/data/connector_test.py
@@ -231,6 +231,7 @@ def test_eventbrite_request(
         result = connector.eventbrite_request("GET", "/test")
         assert result == expected_result
 
+
 def test_cache_server_request(mocker):
     """cache_server_request makes GET to cache server and returns JSON."""
     mock_response = mocker.MagicMock(status_code=200)
@@ -250,7 +251,7 @@ def test_cache_server_request(mocker):
     connector = con.Connector()
     result = connector.cache_server_request("/find_best_match", {"search": "Alice"})
     assert result == [{"a": 1}]
-    con.requests.request.assert_called_with(
+    con.requests.request.assert_called_with(  # pylint: disable=no-member
         "GET",
         "http://localhost:5001/find_best_match",
         params={"search": "Alice"},

--- a/protohaven_api/integrations/data/dev_booked.py
+++ b/protohaven_api/integrations/data/dev_booked.py
@@ -49,8 +49,8 @@ client = app.test_client()
 
 def handle(mode, url, json=None):
     """Local execution of mock flask endpoints for Booked"""
-    if mode == "GET":
-        return client.get(url)
     if mode == "POST":
         return client.post(url, json=json)
+    if mode == "GET":
+        return client.get(url)
     raise RuntimeError(f"mode not supported: {mode}")

--- a/protohaven_api/integrations/data/dev_connector.py
+++ b/protohaven_api/integrations/data/dev_connector.py
@@ -108,3 +108,42 @@ class DevConnector(Connector):
     def gcal_request(self, calendar_id, time_min, time_max):
         """Sends a calendar read request to Google Calendar"""
         return dev_google.get_calendar(calendar_id, time_min, time_max)
+
+    def cache_server_request(self, endpoint: str, params: dict) -> dict:
+        """Dev mode: query the local AccountCache directly instead of making HTTP calls."""
+        # Lazy import to avoid circular dependency at module load time
+        from protohaven_api.integrations import neon  # pylint: disable=import-outside-toplevel
+
+        if endpoint == "/find_best_match":
+            search: str = params.get("search", "")
+            top_n: int = int(params.get("top_n", 10))
+            score_cutoff: int = int(params.get("score_cutoff", 65))
+            results: list[dict] = []
+            for member in neon.cache.find_best_match(
+                search, top_n=top_n, score_cutoff=score_cutoff
+            ):
+                results.append({
+                    "neon_raw_data": member.neon_raw_data,
+                    "neon_search_data": member.neon_search_data,
+                    "neon_membership_data": member.neon_membership_data,
+                    "airtable_bio_data": member.airtable_bio_data,
+                })
+            return results
+
+        if endpoint == "/get":
+            key: str = params.get("key", "")
+            if not key:
+                return {"error": "key parameter is required"}
+            fetch_if_missing: bool = str(params.get("fetch_if_missing", "1")) != "0"
+            data = neon.cache.get(key, {}, fetch_if_missing=fetch_if_missing)
+            result: dict = {}
+            for neon_id, member in data.items():
+                result[neon_id] = {
+                    "neon_raw_data": member.neon_raw_data,
+                    "neon_search_data": member.neon_search_data,
+                    "neon_membership_data": member.neon_membership_data,
+                    "airtable_bio_data": member.airtable_bio_data,
+                }
+            return result
+
+        raise ValueError(f"Unknown cache server endpoint: {endpoint}")

--- a/protohaven_api/integrations/data/dev_connector.py
+++ b/protohaven_api/integrations/data/dev_connector.py
@@ -109,10 +109,14 @@ class DevConnector(Connector):
         """Sends a calendar read request to Google Calendar"""
         return dev_google.get_calendar(calendar_id, time_min, time_max)
 
-    def cache_server_request(self, endpoint: str, params: dict) -> dict:
+    def cache_server_request(  # pylint: disable=too-many-locals
+        self, endpoint: str, params: dict
+    ):
         """Dev mode: query the local AccountCache directly instead of making HTTP calls."""
         # Lazy import to avoid circular dependency at module load time
-        from protohaven_api.integrations import neon  # pylint: disable=import-outside-toplevel
+        from protohaven_api.integrations import (  # pylint: disable=import-outside-toplevel
+            neon,
+        )
 
         if endpoint == "/find_best_match":
             search: str = params.get("search", "")
@@ -122,12 +126,14 @@ class DevConnector(Connector):
             for member in neon.cache.find_best_match(
                 search, top_n=top_n, score_cutoff=score_cutoff
             ):
-                results.append({
-                    "neon_raw_data": member.neon_raw_data,
-                    "neon_search_data": member.neon_search_data,
-                    "neon_membership_data": member.neon_membership_data,
-                    "airtable_bio_data": member.airtable_bio_data,
-                })
+                results.append(
+                    {
+                        "neon_raw_data": member.neon_raw_data,
+                        "neon_search_data": member.neon_search_data,
+                        "neon_membership_data": member.neon_membership_data,
+                        "airtable_bio_data": member.airtable_bio_data,
+                    }
+                )
             return results
 
         if endpoint == "/neon_id_from_booked_id":

--- a/protohaven_api/integrations/data/dev_connector.py
+++ b/protohaven_api/integrations/data/dev_connector.py
@@ -130,6 +130,14 @@ class DevConnector(Connector):
                 })
             return results
 
+        if endpoint == "/neon_id_from_booked_id":
+            booked_id_str: str = params.get("booked_id", "")
+            if not booked_id_str:
+                return {"error": "booked_id parameter is required"}
+            booked_id: int = int(booked_id_str)
+            neon_id: str = neon.cache.neon_id_from_booked_id(booked_id)
+            return {"neon_id": neon_id}
+
         if endpoint == "/get":
             key: str = params.get("key", "")
             if not key:

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -17,6 +17,9 @@ from flask import Response
 
 from protohaven_api.config import get_config, tznow, utcnow
 from protohaven_api.integrations import neon_base
+from protohaven_api.integrations.data.connector import (
+    get as get_connector,  # pylint: disable=import-outside-toplevel
+)
 from protohaven_api.integrations.data.neon import CustomField
 from protohaven_api.integrations.data.warm_cache import WarmDict
 from protohaven_api.integrations.models import (
@@ -831,13 +834,7 @@ def cached_find_best_match(
         List of Member objects matching the search
     """
     if not get_config("cache_server/enabled", False, as_bool=True):
-        return list(
-            cache.find_best_match(search_string, top_n, score_cutoff)
-        )
-
-    from protohaven_api.integrations.data.connector import (  # pylint: disable=import-outside-toplevel
-        get as get_connector,
-    )
+        return list(cache.find_best_match(search_string, top_n, score_cutoff))
 
     data = get_connector().cache_server_request(
         "/find_best_match",
@@ -850,9 +847,7 @@ def cached_find_best_match(
     return [Member(**m) for m in data]
 
 
-def cached_get(
-    email: str, fetch_if_missing: bool = True
-) -> dict[str, Member]:
+def cached_get(email: str, fetch_if_missing: bool = True) -> dict[str, Member]:
     """Query the cache server for members by email.
 
     Falls back to local neon.cache if cache_server is not enabled in config.
@@ -866,15 +861,7 @@ def cached_get(
     """
     if not get_config("cache_server/enabled", False, as_bool=True):
         # Use positional args compatible with both dict.get and AccountCache.get
-        return (
-            cache.get(email, {})
-            if fetch_if_missing
-            else (cache.get(email) or {})
-        )
-
-    from protohaven_api.integrations.data.connector import (  # pylint: disable=import-outside-toplevel
-        get as get_connector,
-    )
+        return cache.get(email, {}) if fetch_if_missing else (cache.get(email) or {})
 
     params: dict = {"key": email}
     if not fetch_if_missing:

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -847,6 +847,27 @@ def cached_find_best_match(
     return [Member(**m) for m in data]
 
 
+def cached_neon_id_from_booked_id(booked_id: int) -> str:
+    """Query the cache server for the Neon ID associated with a Booked user ID.
+
+    Falls back to local neon.cache if cache_server is not enabled in config.
+
+    Args:
+        booked_id: The Booked scheduler user ID
+
+    Returns:
+        The corresponding Neon account ID string
+    """
+    if not get_config("cache_server/enabled", False, as_bool=True):
+        return cache.neon_id_from_booked_id(booked_id)
+
+    data: dict = get_connector().cache_server_request(
+        "/neon_id_from_booked_id",
+        {"booked_id": booked_id},
+    )
+    return str(data["neon_id"])
+
+
 def cached_get(email: str, fetch_if_missing: bool = True) -> dict[str, Member]:
     """Query the cache server for members by email.
 

--- a/protohaven_api/integrations/neon.py
+++ b/protohaven_api/integrations/neon.py
@@ -15,7 +15,7 @@ from typing import Iterable
 import rapidfuzz
 from flask import Response
 
-from protohaven_api.config import tznow, utcnow
+from protohaven_api.config import get_config, tznow, utcnow
 from protohaven_api.integrations import neon_base
 from protohaven_api.integrations.data.neon import CustomField
 from protohaven_api.integrations.data.warm_cache import WarmDict
@@ -813,3 +813,72 @@ class AccountCache(WarmDict):
 
 
 cache = AccountCache()
+
+
+def cached_find_best_match(
+    search_string: str, top_n: int = 10, score_cutoff: int = 65
+) -> list[Member]:
+    """Query the cache server for best member matches by name/email.
+
+    Falls back to local neon.cache if cache_server is not enabled in config.
+
+    Args:
+        search_string: The search string to fuzzy-match against member names/emails
+        top_n: Maximum number of results to return
+        score_cutoff: Minimum fuzzy match score (0-100)
+
+    Returns:
+        List of Member objects matching the search
+    """
+    if not get_config("cache_server/enabled", False, as_bool=True):
+        return list(
+            cache.find_best_match(search_string, top_n, score_cutoff)
+        )
+
+    from protohaven_api.integrations.data.connector import (  # pylint: disable=import-outside-toplevel
+        get as get_connector,
+    )
+
+    data = get_connector().cache_server_request(
+        "/find_best_match",
+        {
+            "search": search_string,
+            "top_n": top_n,
+            "score_cutoff": score_cutoff,
+        },
+    )
+    return [Member(**m) for m in data]
+
+
+def cached_get(
+    email: str, fetch_if_missing: bool = True
+) -> dict[str, Member]:
+    """Query the cache server for members by email.
+
+    Falls back to local neon.cache if cache_server is not enabled in config.
+
+    Args:
+        email: The email address to look up
+        fetch_if_missing: Whether to fall back to Neon API on cache miss
+
+    Returns:
+        Dict mapping Neon IDs to Member objects, or empty dict if not found
+    """
+    if not get_config("cache_server/enabled", False, as_bool=True):
+        # Use positional args compatible with both dict.get and AccountCache.get
+        return (
+            cache.get(email, {})
+            if fetch_if_missing
+            else (cache.get(email) or {})
+        )
+
+    from protohaven_api.integrations.data.connector import (  # pylint: disable=import-outside-toplevel
+        get as get_connector,
+    )
+
+    params: dict = {"key": email}
+    if not fetch_if_missing:
+        params["fetch_if_missing"] = "0"
+
+    data = get_connector().cache_server_request("/get", params)
+    return {neon_id: Member(**m) for neon_id, m in data.items()}

--- a/protohaven_api/main.py
+++ b/protohaven_api/main.py
@@ -43,7 +43,9 @@ init_connector(Connector if server_mode == "prod" else DevConnector)
 log.info("Initializing sign-in precaching")
 # Must run after connector is initialized; prefetches from Neon/Airtable
 if get_config("general/precache_sign_in", as_bool=True):
-    neon.cache.start()
+    if not get_config("cache_server/enabled", False, as_bool=True):
+        # Only create a local cache if we aren't calling out to the cache server
+        neon.cache.start()
     airtable.cache.start()
     booked.cache.start(delay=60.0 if server_mode == "prod" else 0)
     init_signin()

--- a/protohaven_api/main.py
+++ b/protohaven_api/main.py
@@ -92,7 +92,7 @@ def _on_reservations(cache):
     rr = cache.get_today_reservations_by_tool()
     log.debug(f"Reservation cache by tool: {rr}")
     for tool_code, data in rr.items():
-        neon_id = neon.cache.neon_id_from_booked_id(int(data["user"]))
+        neon_id = neon.cached_neon_id_from_booked_id(int(data["user"]))
         log.info(f"Reservation: {tool_code} {neon_id} {data}")
         mqtt.notify_reservation(
             tool_code,


### PR DESCRIPTION
This change decouples the AccountCache instance from the prod flask server. The new "account_cache" server runs in a separate container and provides the same caching features via HTTP requests. 

While this is slightly less performant than an in-process cache, it allows us to run multiple flask server instances via gunicorn so that multiple web requests to the API server can be active at the same time - this provides a number of benefits:

1. should noticeably improve latency for end users
2. allows for persistent websocket sessions which is necessary for e.g. NFC reader support on the sign in kiosk.
3. A step towards modularity (#345)