### PR TITLE
Exploratory fixes for Eventbrite description, plus rollout flag

### DIFF
--- a/protohaven_api/commands/classes.py
+++ b/protohaven_api/commands/classes.py
@@ -365,13 +365,6 @@ class Commands:
             action=argparse.BooleanOptionalAction,
             default=True,
         ),
-        arg(
-            "--use-eventbrite-for",
-            help="Post to eventbrite instead of to Neon CRM; opt in by CSV: "
-            "inst_id1+class_id1,inst_id2+class_id2 etc. "
-            "Use * to send all events through eventbrite",
-            type=str,
-        ),
     )
     def post_classes_to_neon(
         self, args, _
@@ -390,24 +383,6 @@ class Commands:
             f"Equipment will {'NOT ' if not args.reserve else ''}be reserved for new classes"
         )
 
-        eb_filter_items = {}
-        if args.use_eventbrite_for == "*":
-            log.info("All events will schedule through eventbrite")
-        elif args.use_eventbrite_for:
-            uses = [mm.split("+") for mm in args.use_eventbrite_for.split(",")]
-            log.info(
-                "Eventbrite will be used if matching these instructor+class combos: "
-                f"{uses}"
-            )
-            eb_filter_items = {
-                (str(inst_id), str(class_id)) for inst_id, class_id in uses
-            }
-
-        def eb_filter(inst_id, class_id):
-            if args.use_eventbrite_for == "*":
-                return True
-            return (str(inst_id), str(class_id)) in eb_filter_items
-
         if args.ovr:
             log.info(
                 "Overriding to specifically schedule ONLY classes in Airtable "
@@ -421,8 +396,8 @@ class Commands:
         scheduled_by_instructor = defaultdict(list)
         to_schedule.sort(key=lambda e: e.start_time)
 
-        log.info("Attempting auth as user to allow for pricing changes")
-        session = None if args.use_eventbrite_for == "*" else neon_base.NeonOne()
+        log.info("Attempting Neon auth as user to allow for pricing changes")
+        session = neon_base.NeonOne()
 
         log.info(f"Scheduling {len(to_schedule)} events:")
         for event in to_schedule:
@@ -433,12 +408,12 @@ class Commands:
                 f"${event.price}, {event.capacity} students, sessions "
                 f"{[s[0].strftime('%Y-%m-%d %-I:%M %p') for s in event.sessions]}"
             )
+            log.info(f"use_eventbrite={event.use_eventbrite}")
 
             num += 1
             result_id = None
             try:
-                use_eventbrite = eb_filter(event.class_id, event.instructor_id)
-                if args.apply and not use_eventbrite:
+                if args.apply and not event.use_eventbrite:
                     result_id = neon_base.create_event(
                         event.name,
                         desc=self._format_class_description(event),
@@ -450,7 +425,7 @@ class Commands:
                         published=args.publish,
                         registration=args.registration,
                     )
-                elif args.apply and use_eventbrite:
+                elif args.apply and event.use_eventbrite:
                     image_id = None
                     if event.image_link:
                         log.info(
@@ -473,7 +448,7 @@ class Commands:
                 assert result_id
                 event.event_id = result_id
 
-                if args.apply and use_eventbrite:
+                if args.apply and event.use_eventbrite:
                     desc = self._format_class_description(event, include_summary=False)
                     content_version = eventbrite.set_structured_content(
                         event.event_id, desc
@@ -483,7 +458,7 @@ class Commands:
                     )
 
                 log.info("- Assigning pricing")
-                if args.apply and not use_eventbrite:
+                if args.apply and not event.use_eventbrite:
                     log.info("  (uses Firefox process via playwright)")
                     session.assign_pricing(
                         event.event_id,
@@ -493,7 +468,7 @@ class Commands:
                         clear_existing=True,
                     )
                     log.info("  Pricing assigned")
-                elif args.apply and use_eventbrite:
+                elif args.apply and event.use_eventbrite:
                     log.info(
                         str(
                             eventbrite.assign_pricing(
@@ -538,7 +513,7 @@ class Commands:
                 log.error(traceback.format_exc())
                 if result_id:
                     log.error("Failed; reverting event creation")
-                    if use_eventbrite:
+                    if event.use_eventbrite:
                         log.info(eventbrite.delete_event_unsafe(result_id))
                     else:
                         log.info(neon_base.delete_event_unsafe(result_id))

--- a/protohaven_api/commands/classes.py
+++ b/protohaven_api/commands/classes.py
@@ -244,7 +244,9 @@ class Commands:
         result += "\n".join([f"* {l}" for l in lines])
         return result
 
-    def _format_class_description(self, cls: airtable.ScheduledClass):
+    def _format_class_description(
+        self, cls: airtable.ScheduledClass, include_summary=True
+    ):
         """Construct description of class from airtable columns; strip 'from Class' suffix"""
         (
             rules_and_expectations,
@@ -254,6 +256,8 @@ class Commands:
         result = ""
         if cls.image_link:
             result += f'<p><img height="200" src="{cls.image_link}"/></p>\n'
+        if include_summary:
+            result += "<p>" + cls.description["Summary (max 140 chars)"] + "</p>\n"
         result += markdown.markdown(cls.description["Short Description"]) + "\n"
         sections = []
         for col in (
@@ -458,6 +462,7 @@ class Commands:
                     result_id = eventbrite.create_event(
                         event.name,
                         event.sessions,
+                        summary=event.description["Summary (max 140 chars)"],
                         max_attendees=event.capacity,
                         published=args.publish,
                         logo_id=image_id,
@@ -469,7 +474,7 @@ class Commands:
                 event.event_id = result_id
 
                 if args.apply and use_eventbrite:
-                    desc = self._format_class_description(event)
+                    desc = self._format_class_description(event, include_summary=False)
                     content_version = eventbrite.set_structured_content(
                         event.event_id, desc
                     )

--- a/protohaven_api/commands/classes_test.py
+++ b/protohaven_api/commands/classes_test.py
@@ -145,6 +145,7 @@ def test_format_class_description(mocker):
         mocker.MagicMock(
             image_link="link",
             description={
+                "Summary (max 140 chars)": "summary",
                 "Short Description": "short_desc",
                 "What you Will Create": "what_create",
                 "What to Bring/Wear": "what_bring",
@@ -160,7 +161,7 @@ def test_format_class_description(mocker):
     )
     assert (
         result
-        == '<p><img height="200" src="link"/></p>\n<p>short_desc</p>\n<p><strong>What you Will Create</strong></p>\n<p>what_create</p>\n\n<p><strong>What to Bring/Wear</strong></p>\n<p>what_bring</p>\n\n<p><strong>Clearances Earned</strong></p>\n<p>clearances</p>\n\n<p><strong>Age Requirement</strong></p>\n<p>age_section_fmt</p><p><strong>Class Dates</strong></p>\n<ul>\n<li>Wednesday Jan 1, 8AM - 11AM</li>\n<li>Wednesday Jan 8, 8AM - 11AM</li>\n<li>Wednesday Jan 15, 8AM - 11AM</li>\n</ul><p>rules_and_expectations</p><p>cancellation_policy</p>'
+        == '<p><img height="200" src="link"/></p>\n<p>summary</p>\n<p>short_desc</p>\n<p><strong>What you Will Create</strong></p>\n<p>what_create</p>\n\n<p><strong>What to Bring/Wear</strong></p>\n<p>what_bring</p>\n\n<p><strong>Clearances Earned</strong></p>\n<p>clearances</p>\n\n<p><strong>Age Requirement</strong></p>\n<p>age_section_fmt</p><p><strong>Class Dates</strong></p>\n<ul>\n<li>Wednesday Jan 1, 8AM - 11AM</li>\n<li>Wednesday Jan 8, 8AM - 11AM</li>\n<li>Wednesday Jan 15, 8AM - 11AM</li>\n</ul><p>rules_and_expectations</p><p>cancellation_policy</p>'
     )
 
 
@@ -179,6 +180,7 @@ def _tcls(mocker):
             (d(20, 8), d(20, 11)),
         ],
         description={
+            "Summary (max 140 chars)": "summary",
             "Short Description": "testdesc",
             "What you Will Create": "a thing",
             "What to Bring/Wear": "stuff",

--- a/protohaven_api/commands/classes_test.py
+++ b/protohaven_api/commands/classes_test.py
@@ -192,6 +192,7 @@ def _tcls(mocker):
         capacity=6,
         price=90,
         instructor_email="a@b.com",
+        use_eventbrite=False,
     )
     c.name = "test class"
     return c

--- a/protohaven_api/integrations/airtable.py
+++ b/protohaven_api/integrations/airtable.py
@@ -193,7 +193,7 @@ class ScheduledClass:  # pylint: disable=too-many-instance-attributes
                     "Age Requirement",
                 )
             },
-            use_eventbrite=f.get("Eventbrite (from Class)") or False,
+            use_eventbrite=_unwrap(f, "Eventbrite (from Class)") or False,
         )
 
     def form_fmt_hours(self, h: float) -> str:

--- a/protohaven_api/integrations/airtable.py
+++ b/protohaven_api/integrations/airtable.py
@@ -108,6 +108,7 @@ class Class:  # pylint: disable=too-many-instance-attributes
 class ScheduledClass:  # pylint: disable=too-many-instance-attributes
     """Represents a class template with scheduling information applied"""
 
+    use_eventbrite: bool
     schedule_id: RecordID  # Record ID for the Schedule table
     class_id: RecordID  # Record ID for the Class Templates table
     event_id: EventID  # Neon or Eventbrite published ID
@@ -192,6 +193,7 @@ class ScheduledClass:  # pylint: disable=too-many-instance-attributes
                     "Age Requirement",
                 )
             },
+            use_eventbrite=f.get("Eventbrite (from Class)") or False,
         )
 
     def form_fmt_hours(self, h: float) -> str:

--- a/protohaven_api/integrations/airtable.py
+++ b/protohaven_api/integrations/airtable.py
@@ -184,6 +184,7 @@ class ScheduledClass:  # pylint: disable=too-many-instance-attributes
             description={
                 k: _unwrap(f, k + " (from Class)") or ""
                 for k in (
+                    "Summary (max 140 chars)",
                     "Short Description",
                     "What you Will Create",
                     "What to Bring/Wear",

--- a/protohaven_api/integrations/airtable_test.py
+++ b/protohaven_api/integrations/airtable_test.py
@@ -462,6 +462,7 @@ def test_from_schedule(mocker):
             "Email": "instructor@example.com",
             "Instructor": "John Doe",
             "Volunteer": False,
+            "Summary (max 140 chars) (from Class)": ["Summary"],
             "Short Description (from Class)": ["A short description"],
             "What you Will Create (from Class)": ["A wooden box"],
             "What to Bring/Wear (from Class)": ["Safety glasses"],
@@ -492,6 +493,7 @@ def test_from_schedule(mocker):
     expected_sessions = [(d(6, 10), d(6, 13)), (d(7, 10), d(7, 13))]
     assert result.sessions == expected_sessions
     assert result.description == {
+        "Summary (max 140 chars)": "Summary",
         "Short Description": "A short description",
         "What you Will Create": "A wooden box",
         "What to Bring/Wear": "Safety glasses",

--- a/protohaven_api/integrations/eventbrite.py
+++ b/protohaven_api/integrations/eventbrite.py
@@ -127,6 +127,7 @@ def _utcfmt(d: datetime.datetime) -> str:
 def create_event(  # pylint: disable=too-many-arguments
     name: str,
     sessions: list[Interval],
+    summary: str | None = None,
     max_attendees: int = 6,
     published: bool = True,
     logo_id: int | None = None,
@@ -155,6 +156,7 @@ def create_event(  # pylint: disable=too-many-arguments
             "listed": published,
             "show_remaining": True,
             "capacity": max_attendees,
+            "summary": summary,
             "logo_id": logo_id,
             # "is_series": len(sessions) > 1,
         }

--- a/protohaven_api/integrations/eventbrite.py
+++ b/protohaven_api/integrations/eventbrite.py
@@ -271,7 +271,7 @@ def assign_pricing(
             "name": "General Admission",
             "sales_end_relative": {
                 "relative_to_event": "start_time",
-                "offset": -3600
+                "offset": 3600
                 * 24,  # Note offset is negative, so sales end *before* start
             },
             "hide_sale_dates": True,

--- a/protohaven_api/integrations/eventbrite_test.py
+++ b/protohaven_api/integrations/eventbrite_test.py
@@ -104,7 +104,7 @@ def test_assign_pricing(mocker):
             "name": "General Admission",
             "sales_end_relative": {
                 "relative_to_event": "start_time",
-                "offset": -3600 * 24,  # 24 hours BEFORE event
+                "offset": 3600 * 24,  # 24 hours BEFORE event
             },
             "hide_sale_dates": True,
         }

--- a/protohaven_api/integrations/models.py
+++ b/protohaven_api/integrations/models.py
@@ -1113,7 +1113,7 @@ class Event:  # pylint: disable=too-many-public-methods
             "description": (
                 "description",
                 "Event Description",
-                ["description", "html"],
+                ["summary"],
             ),
         }
         if attr in resolvable_fields:

--- a/protohaven_api/integrations/models_test.py
+++ b/protohaven_api/integrations/models_test.py
@@ -431,7 +431,7 @@ def test_event_properties():  # pylint: disable=too-many-statements
     eventbrite = {
         "id": "456",
         "name": {"text": "Test Event"},
-        "description": {"html": "Test Description"},
+        "summary": "summary",
         "capacity": 10,
         "start": {"utc": start.isoformat()},
         "end": {"utc": end.isoformat()},


### PR DESCRIPTION
Switch to using an `Eventbrite` checkbox in Airtable's Class Templates table for easier opt in/out 
Partition away a "summary" section from class descriptions to match Eventbrite's API 