### PR TITLE
Add NFC tap status indicator to welcome page

### DIFF
--- a/protohaven_api/handlers/index.py
+++ b/protohaven_api/handlers/index.py
@@ -84,26 +84,61 @@ def welcome_sock(ws):
 
 def welcome_neon_ws(ws):  # pylint: disable=too-many-statements
     """Persistent websocket that listens for Neon ID badge scans and toast
-    notifications via MQTT. Messages are forwarded to the Svelte frontend."""
+    notifications via MQTT. Messages are forwarded to the Svelte frontend.
+    Also tracks NFC device heartbeat and MQTT broker status, sending periodic
+    status updates to the client."""
     log.info("welcome_neon_ws init")
     neon_signin_topic = get_config("mqtt/neon_signin_topic")
     neon_toast_topic = get_config("mqtt/neon_toast_topic")
+    nfc_heartbeat_topic = "protohaven_api/v1/kiosk/nfc_device/heartbeat"
+
+    # Track NFC device heartbeat
+    nfc_last_heartbeat = None
 
     def handle_message(topic: str, data: dict):
         """We handle message parsing on the client side"""
         ws.send(json.dumps({"origin": topic, "data": data}))
 
+    def handle_nfc_heartbeat(_topic: str, data: dict):
+        """Track NFC device heartbeats"""
+        nonlocal nfc_last_heartbeat
+        nfc_last_heartbeat = time.time()
+        log.debug(f"NFC heartbeat received: {data}")
+
+    def send_status():
+        """Send NFC/MQTT connection status to the client"""
+        mqtt_connected = mqtt_client and mqtt_client.c.is_connected()
+        nfc_age = (
+            None if nfc_last_heartbeat is None else time.time() - nfc_last_heartbeat
+        )
+        ws.send(
+            json.dumps(
+                {
+                    "type": "status",
+                    "server_mqtt_connected": bool(mqtt_connected),
+                    "nfc_heartbeat_age_sec": nfc_age,
+                }
+            )
+        )
+
     mqtt_client = mqtt.get()
     if mqtt_client:
         mqtt_client.register_topic_callback(neon_signin_topic, handle_message)
         mqtt_client.register_topic_callback(neon_toast_topic, handle_message)
+        mqtt_client.register_topic_callback(nfc_heartbeat_topic, handle_nfc_heartbeat)
         log.info("Registered welcome_neon_ws listeners")
     else:
         log.info("MQTT client not set up; aborting")
         return Response("MQTT client not set up", status=500)
     try:
+        # Send initial status
+        send_status()
         while True:
-            data = ws.receive()
+            data = ws.receive(timeout=5)
+            if data is None:
+                # Timeout — send periodic status update
+                send_status()
+                continue
             msg = json.loads(data)
             if msg.get("type") == "ping":
                 ws.send(json.dumps({"type": "pong"}))
@@ -111,6 +146,9 @@ def welcome_neon_ws(ws):  # pylint: disable=too-many-statements
         if mqtt_client:
             mqtt_client.unregister_topic_callback(neon_signin_topic, handle_message)
             mqtt_client.unregister_topic_callback(neon_toast_topic, handle_message)
+            mqtt_client.unregister_topic_callback(
+                nfc_heartbeat_topic, handle_nfc_heartbeat
+            )
     log.info("Neon sign-in WS listener ended")
 
 

--- a/svelte/src/lib/nfc_status.svelte
+++ b/svelte/src/lib/nfc_status.svelte
@@ -1,4 +1,5 @@
-<script lang="ts">
+<script type="typescript" lang="ts">
+  import { Tooltip, Icon } from '@sveltestrap/sveltestrap';
   // nfc_status.svelte — indicator showing NFC tap system health
   // Tracks three independent failure modes:
   //   1. Client WebSocket to Flask server
@@ -9,7 +10,7 @@
   export let server_mqtt_connected: boolean = false;
   export let nfc_heartbeat_age_sec: number | null = null;
 
-  const NFC_HEARTBEAT_TIMEOUT_SEC = 30;
+  const NFC_HEARTBEAT_TIMEOUT_SEC = 60;
 
   $: nfc_alive =
     nfc_heartbeat_age_sec !== null &&
@@ -20,19 +21,19 @@
   // Inlined tooltip derivation — avoid function call so Svelte 4
   // properly tracks all reactive dependencies in $$.update.
   $: tooltip_lines = all_ok
-    ? ["NFC tap system online"]
+    ? [`NFC tap system online; last contact ${Math.round(nfc_heartbeat_age_sec)}s`]
     : [
         ...(!client_ws_connected
-          ? ["\u2022 Browser WebSocket disconnected from server"]
+          ? ["Browser WebSocket disconnected from server"]
           : []),
         ...(!server_mqtt_connected
-          ? ["\u2022 Server cannot connect to MQTT broker"]
+          ? ["Server cannot connect to MQTT broker"]
           : []),
         ...(!nfc_alive
           ? nfc_heartbeat_age_sec === null
-            ? ["\u2022 NFC device heartbeat never received"]
+            ? ["NFC device heartbeat never received"]
             : [
-                `\u2022 NFC device heartbeat stale (${Math.round(
+                `NFC device heartbeat stale (${Math.round(
                   nfc_heartbeat_age_sec
                 )}s ago, limit ${NFC_HEARTBEAT_TIMEOUT_SEC}s)`
               ]
@@ -40,30 +41,18 @@
       ];
 </script>
 
+<Tooltip target="nfc-indicator">
+  {#each tooltip_lines as tl}
+  <p>{tl}</p>
+  {/each}
+</Tooltip>
 <div
   class="nfc-indicator"
+  id="nfc-indicator"
   class:online={all_ok}
   class:offline={!all_ok}
-  title={tooltip_lines.join("&#10;")}
 >
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    class="nfc-icon"
-  >
-    <!-- NFC symbol: antenna + wave -->
-    <path d="M6 8.32a7.43 7.43 0 0 1 0 7.36" />
-    <path d="M9.46 5.11a9.53 9.53 0 0 1 0 13.78" />
-    <path d="M12.91 1.89a12.64 12.64 0 0 1 0 20.22" />
-    <rect x="4" y="2" width="16" height="20" rx="2" ry="2" />
-    <line x1="8" y1="2" x2="8" y2="22" />
-  </svg>
-  <span class="status-dot" class:online={all_ok} class:offline={!all_ok} />
+  <Icon name="wifi" />Tap Sign In {all_ok ? "Online" : "Offline"}
 </div>
 
 <style>

--- a/svelte/src/lib/nfc_status.svelte
+++ b/svelte/src/lib/nfc_status.svelte
@@ -17,27 +17,27 @@
 
   $: all_ok = client_ws_connected && server_mqtt_connected && nfc_alive;
 
-  $: tooltip_lines = getTooltipLines();
-
-  function getTooltipLines(): string[] {
-    if (all_ok) return ["NFC tap system online"];
-    const lines: string[] = [];
-    if (!client_ws_connected) {
-      lines.push("• Browser WebSocket disconnected from server");
-    }
-    if (!server_mqtt_connected) {
-      lines.push("• Server cannot connect to MQTT broker");
-    }
-    if (!nfc_alive) {
-      if (nfc_heartbeat_age_sec === null) {
-        lines.push("• NFC device heartbeat never received");
-      } else {
-        const age = Math.round(nfc_heartbeat_age_sec);
-        lines.push(`• NFC device heartbeat stale (${age}s ago, limit ${NFC_HEARTBEAT_TIMEOUT_SEC}s)`);
-      }
-    }
-    return lines;
-  }
+  // Inlined tooltip derivation — avoid function call so Svelte 4
+  // properly tracks all reactive dependencies in $$.update.
+  $: tooltip_lines = all_ok
+    ? ["NFC tap system online"]
+    : [
+        ...(!client_ws_connected
+          ? ["\u2022 Browser WebSocket disconnected from server"]
+          : []),
+        ...(!server_mqtt_connected
+          ? ["\u2022 Server cannot connect to MQTT broker"]
+          : []),
+        ...(!nfc_alive
+          ? nfc_heartbeat_age_sec === null
+            ? ["\u2022 NFC device heartbeat never received"]
+            : [
+                `\u2022 NFC device heartbeat stale (${Math.round(
+                  nfc_heartbeat_age_sec
+                )}s ago, limit ${NFC_HEARTBEAT_TIMEOUT_SEC}s)`
+              ]
+          : [])
+      ];
 </script>
 
 <div

--- a/svelte/src/lib/nfc_status.svelte
+++ b/svelte/src/lib/nfc_status.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  // nfc_status.svelte — indicator showing NFC tap system health
+  // Tracks three independent failure modes:
+  //   1. Client WebSocket to Flask server
+  //   2. Server MQTT connection to broker
+  //   3. NFC device heartbeat (30s threshold)
+
+  export let client_ws_connected: boolean = false;
+  export let server_mqtt_connected: boolean = false;
+  export let nfc_heartbeat_age_sec: number | null = null;
+
+  const NFC_HEARTBEAT_TIMEOUT_SEC = 30;
+
+  $: nfc_alive =
+    nfc_heartbeat_age_sec !== null &&
+    nfc_heartbeat_age_sec <= NFC_HEARTBEAT_TIMEOUT_SEC;
+
+  $: all_ok = client_ws_connected && server_mqtt_connected && nfc_alive;
+
+  $: tooltip_lines = getTooltipLines();
+
+  function getTooltipLines(): string[] {
+    if (all_ok) return ["NFC tap system online"];
+    const lines: string[] = [];
+    if (!client_ws_connected) {
+      lines.push("• Browser WebSocket disconnected from server");
+    }
+    if (!server_mqtt_connected) {
+      lines.push("• Server cannot connect to MQTT broker");
+    }
+    if (!nfc_alive) {
+      if (nfc_heartbeat_age_sec === null) {
+        lines.push("• NFC device heartbeat never received");
+      } else {
+        const age = Math.round(nfc_heartbeat_age_sec);
+        lines.push(`• NFC device heartbeat stale (${age}s ago, limit ${NFC_HEARTBEAT_TIMEOUT_SEC}s)`);
+      }
+    }
+    return lines;
+  }
+</script>
+
+<div
+  class="nfc-indicator"
+  class:online={all_ok}
+  class:offline={!all_ok}
+  title={tooltip_lines.join("&#10;")}
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="nfc-icon"
+  >
+    <!-- NFC symbol: antenna + wave -->
+    <path d="M6 8.32a7.43 7.43 0 0 1 0 7.36" />
+    <path d="M9.46 5.11a9.53 9.53 0 0 1 0 13.78" />
+    <path d="M12.91 1.89a12.64 12.64 0 0 1 0 20.22" />
+    <rect x="4" y="2" width="16" height="20" rx="2" ry="2" />
+    <line x1="8" y1="2" x2="8" y2="22" />
+  </svg>
+  <span class="status-dot" class:online={all_ok} class:offline={!all_ok} />
+</div>
+
+<style>
+  .nfc-indicator {
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
+    z-index: 9998;
+    cursor: default;
+    transition: background 0.3s;
+  }
+
+  .nfc-indicator.offline {
+    background: rgba(255, 240, 240, 0.95);
+  }
+
+  .nfc-icon {
+    width: 22px;
+    height: 22px;
+    opacity: 0.7;
+  }
+
+  .offline .nfc-icon {
+    color: #c44;
+  }
+
+  .online .nfc-icon {
+    color: #494;
+  }
+
+  .status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .status-dot.online {
+    background: #4a4;
+    box-shadow: 0 0 6px rgba(68, 170, 68, 0.5);
+  }
+
+  .status-dot.offline {
+    background: #c44;
+    box-shadow: 0 0 6px rgba(204, 68, 68, 0.4);
+  }
+</style>

--- a/svelte/src/routes/welcome/+page.svelte
+++ b/svelte/src/routes/welcome/+page.svelte
@@ -63,7 +63,6 @@
       console.error("Neon sign-in WS error:", err);
     };
     neon_ws.onmessage = (event) => {
-      console.log(event);
       let data = JSON.parse(event.data);
 
       if (data.type === "status") {

--- a/svelte/src/routes/welcome/+page.svelte
+++ b/svelte/src/routes/welcome/+page.svelte
@@ -8,6 +8,7 @@
   import MembershipExpired from '$lib/membership_expired.svelte';
 	import Waiver from '$lib/waiver.svelte';
   import MemberAgreement from '$lib/member_agreement.svelte';
+  import NfcStatus from '$lib/nfc_status.svelte';
   let state='splash';
   let name='member';
   let email=null;
@@ -27,6 +28,9 @@
 
   let neon_ws = null;
   let neon_ws_connected = false;
+  let server_mqtt_connected = false;
+  /** @type {number | null} */
+  let nfc_heartbeat_age_sec = null;
   let toast_msg = null;
   let toast_timer = null;
 
@@ -62,7 +66,10 @@
       console.log(event);
       let data = JSON.parse(event.data);
 
-      if (data.origin.endsWith("signin")) {
+      if (data.type === "status") {
+        server_mqtt_connected = data.server_mqtt_connected;
+        nfc_heartbeat_age_sec = data.nfc_heartbeat_age_sec;
+      } else if (data.origin.endsWith("signin")) {
         console.log("Received sign in attempt via MQTT:", data.data);
         // If we're already showing sign-in result, restart the flow first
         if (state === 'signin_ok') {
@@ -233,6 +240,12 @@
 	</Row>
 </main>
 
+<NfcStatus
+    client_ws_connected={neon_ws_connected}
+    server_mqtt_connected={server_mqtt_connected}
+    nfc_heartbeat_age_sec={nfc_heartbeat_age_sec}
+  />
+
 <svelte:window
     on:keyup={(e) => {
       if (e.key == 'Enter' && state==="signin_ok") {
@@ -241,7 +254,6 @@
       }
     }}
 />
-
 
 
 <style>


### PR DESCRIPTION
#596

Add a bottom-right visual indicator on the /welcome kiosk page showing whether the NFC badge tap system is operational. A green dot means everything is online; a red dot means something is offline.

Hovering over the indicator when offline shows which of three conditions is causing the issue:
  1. Browser WebSocket disconnected from server (client-side)
  2. Server cannot connect to MQTT broker
  3. NFC device heartbeat not received in 30 seconds

Server-side changes (welcome_neon_ws):
- Subscribe to NFC heartbeat topic (protohaven_api/v1/kiosk/nfc_device/heartbeat)
- Check MQTT broker connection status via mqtt_client.c.is_connected()
- Send periodic status updates to client every 5s via ws.receive(timeout=5)

Client-side changes:
- New nfc_status.svelte component with SVG NFC icon and colored dot
- Welcome page updated to track and display server_mqtt_connected and nfc_heartbeat_age_sec from WebSocket status messages