### PR TITLE
fix: store shift overrides as deltas instead of absolute lists

### DIFF
--- a/protohaven_api/automation/techs/techs.py
+++ b/protohaven_api/automation/techs/techs.py
@@ -84,49 +84,122 @@ def _calendar_badge_color(num_people):
     return "danger"
 
 
+def _resolve_name_to_member(name: str) -> Member | None:
+    """Resolve a tech name string to a Member object.
+    Returns None if not found in Neon (guest tech)."""
+    name = re.sub(r"\(.*\)", "", name)  # remove pronouns for matching purposes
+    name = re.sub(r" +", " ", name)  # prevent double-space issues
+    mm = list(neon.cached_find_best_match(name))
+    log.info(f"Seeking match for tech {name}")
+    for m in mm:
+        # Checking with removed pronouns
+        candidate = re.sub(r"\(.*\)", "", m.name).strip().lower()
+        log.info(f"Candidate {candidate} vs {name.strip().lower()}")
+        if candidate == name.strip().lower():
+            return mm[0]
+    return None
+
+
+def _create_guest_member(name: str) -> Member:
+    """Create a name-only Member object for a guest tech not found in Neon."""
+    log.warning(
+        f"Tech override not found in neon: {name}. Creating name-only Member object"
+    )
+    ns = [n.strip() for n in name.split(" ")][:2]
+    return cast(
+        Member,
+        Member.from_neon_search(
+            {
+                "First Name": ns[0] if len(ns) > 0 else "",
+                "Last Name": ns[1] if len(ns) > 1 else "",
+            }
+        ),
+    )
+
+
+def _is_delta_format(entries: list[str]) -> bool:
+    """Detect if override entries use the delta format (prefixed with + or -).
+    Returns True if any entry starts with + or -, indicating delta format.
+    An empty list is treated as non-delta (no override)."""
+    if not entries:
+        return False
+    return any(e.startswith("+") or e.startswith("-") for e in entries)
+
+
+def _apply_delta_overrides(
+    shift_people: list[Member], ovr_entries: list[str]
+) -> list[Member]:
+    """Apply delta-format overrides on top of shift_people.
+
+    Entries are '+' for additions, '-' for removals."""
+    result: list[Member] = list(shift_people)
+    names_lower = {p.name.strip().lower() for p in result}
+
+    for entry in ovr_entries:
+        if not entry:
+            continue
+        prefix = entry[0]
+        name = entry[1:].strip()
+        raw_name = re.sub(r"\(.*\)", "", name).strip().lower()
+
+        if prefix == "+" and raw_name not in names_lower:
+            member = _resolve_name_to_member(name)
+            if member is None:
+                member = _create_guest_member(name)
+            result.append(member)
+            names_lower.add(raw_name)
+        elif prefix == "-":
+            result = [
+                p
+                for p in result
+                if re.sub(r"\(.*\)", "", p.name).strip().lower() != raw_name
+            ]
+            names_lower = {
+                re.sub(r"\(.*\)", "", p.name).strip().lower() for p in result
+            }
+
+    return result
+
+
+def _resolve_legacy_overrides(ovr_entries: list[str]) -> list[Member]:
+    """Resolve legacy (absolute) override entries into Member objects."""
+    result: list[Member] = []
+    for p in ovr_entries:
+        p_clean = re.sub(r"\(.*\)", "", p)  # remove pronouns
+        p_clean = re.sub(r" +", " ", p_clean)  # prevent double-space
+        member = _resolve_name_to_member(p_clean)
+        if member is None:
+            member = _create_guest_member(p_clean)
+        result.append(member)
+    return result
+
+
 def resolve_overrides(
-    overrides: dict[str, airtable.ForecastOverride], shift
+    overrides: dict[str, airtable.ForecastOverride],
+    shift: str,
+    shift_people: list[Member],
 ) -> tuple[str | None, list[Member], str | None]:
-    """We must translate overrides into Member instances, with
-    special handling of "guest" techs if they do not exist in Neon.
+    """Translate overrides into Member instances.
+
+    Supports two formats:
+    - Delta format (new): entries prefixed with '+' (additions) or '-' (removals).
+      Applied on top of shift_people (the default techs for that shift).
+      This ensures newly enrolled techs appear in previously-overridden shifts.
+    - Legacy format: absolute list of tech names. Used directly as the final list.
+
+    Special handling of "guest" techs if they do not exist in Neon.
 
     Note that caching must be used here as otherwise calendar views of
-    forecasted tech dates slow to a crawl due to the number of one-off fetches"""
-    ovr_id, ovr_people_in, ovr_editor = overrides.get(shift) or (None, [], None)
-    ovr_people_out: list[Member] = []
+    forecasted tech dates slow to a crawl due to the number of one-off fetches."""
+    ovr_id, ovr_entries, ovr_editor = overrides.get(shift) or (None, [], None)
 
-    for p in ovr_people_in:
-        p = re.sub(r"\(.*\)", "", p)  # remove pronouns for matching purposes
-        p = re.sub(r" +", " ", p)  # prevent double-space issues
-        mm = list(neon.cached_find_best_match(p))
-        found = False
-        log.info(f"Seeking match for tech override {p}")
-        for m in mm:
-            # Checking with removed pronouns
-            candidate = re.sub(r"\(.*\)", "", m.name).strip().lower()
-            log.info(f"Candidate {candidate} vs {p.strip().lower()}")
-            if candidate == p.strip().lower():
-                ovr_people_out.append(mm[0])
-                found = True
-                break
+    if not ovr_id or not ovr_entries:
+        return None, [], None
 
-        if not found:
-            log.warning(
-                f"Tech override not found in neon: {p}. Creating name-only Member object"
-            )
-            ns = [n.strip() for n in p.split(" ")][:2]
-            ovr_people_out.append(
-                cast(
-                    Member,
-                    Member.from_neon_search(
-                        {
-                            "First Name": ns[0] if len(ns) > 0 else "",
-                            "Last Name": ns[1] if len(ns) > 1 else "",
-                        }
-                    ),
-                )
-            )
-    return ovr_id, ovr_people_out, ovr_editor
+    if _is_delta_format(ovr_entries):
+        return ovr_id, _apply_delta_overrides(shift_people, ovr_entries), ovr_editor
+
+    return ovr_id, _resolve_legacy_overrides(ovr_entries), ovr_editor
 
 
 def create_calendar_view(  # pylint: disable=too-many-locals, too-many-nested-blocks
@@ -143,10 +216,6 @@ def create_calendar_view(  # pylint: disable=too-many-locals, too-many-nested-bl
         for ap in ("AM", "PM"):
             wd = d.strftime("%A")
 
-            ovr_id, ovr_people, ovr_editor = resolve_overrides(
-                overrides, f"{dstr} {ap}"
-            )
-
             # On holidays, we assume by default that nobody is on duty.
             people_in = shift_map.get((wd, ap), []) if d not in ph_holidays else []
 
@@ -156,6 +225,10 @@ def create_calendar_view(  # pylint: disable=too-many-locals, too-many-nested-bl
                     p.shop_tech_last_day is None or p.shop_tech_last_day >= d
                 ):
                     shift_people.append(p)
+
+            ovr_id, ovr_people, ovr_editor = resolve_overrides(
+                overrides, f"{dstr} {ap}", shift_people
+            )
 
             final_people = ovr_people if ovr_id else shift_people
 

--- a/protohaven_api/automation/techs/techs_test.py
+++ b/protohaven_api/automation/techs/techs_test.py
@@ -1,5 +1,7 @@
 """Test tech automation (e.g. shift forecast generation"""
 
+import unittest.mock
+
 import pytest
 
 from protohaven_api.automation.techs import techs as t
@@ -65,19 +67,24 @@ def test_create_calendar_view(mocker, test_date, ovr, want_am, is_holiday):
     assert result[0]["is_holiday"] == is_holiday
 
 
-def test_resolve_overrides(mocker):
-    """Test resolving tech overrides with various scenarios"""
-    # Setup test data
+def _mock_tech(name):
+    """Helper to create a mock Member with a name"""
+    m = unittest.mock.MagicMock()
+    m.name = name
+    return m
+
+
+def test_resolve_overrides_legacy_format(mocker):
+    """Test resolving tech overrides with legacy (absolute) format"""
     test_overrides = {
         "shift1": ("id1", ["John Doe", "Jane   smith (they/them)"], "editor1"),
         "shift2": ("id2", ["GuestTech"], None),
     }
+    shift_people = []  # Not used in legacy mode
 
-    # Mock neon.search_members_by_name
-    mock_member1 = mocker.MagicMock()
-    mock_member1.name = "John Doe"
-    mock_member2 = mocker.MagicMock()
-    mock_member2.name = "Jane Smith"
+    # Mock neon.find_best_match
+    mock_member1 = _mock_tech("John Doe")
+    mock_member2 = _mock_tech("Jane Smith")
     mocker.patch.object(
         t.neon.cache,
         "find_best_match",
@@ -88,19 +95,176 @@ def test_resolve_overrides(mocker):
         ],
     )
 
-    # Test shift with existing members
-    got = t.resolve_overrides(test_overrides, "shift1")
+    # Test shift with existing members (legacy absolute format)
+    got = t.resolve_overrides(test_overrides, "shift1", shift_people)
     assert got[0] == "id1"
     assert got[1] == [mock_member1, mock_member2]
     assert got[2] == "editor1"
 
     # Test shift with guest tech
-    got = t.resolve_overrides(test_overrides, "shift2")
+    got = t.resolve_overrides(test_overrides, "shift2", shift_people)
     assert got[0] == "id2"
     assert len(got[1]) == 1
     assert got[1][0].name == "GuestTech"
     assert got[2] is None
 
     # Test shift not in overrides
-    got = t.resolve_overrides(test_overrides, "missing_shift")
+    got = t.resolve_overrides(test_overrides, "missing_shift", shift_people)
+    assert got == (None, [], None)
+
+
+def test_resolve_overrides_delta_format_add(mocker):
+    """Test delta format: adding a tech to a shift"""
+    default_tech = _mock_tech("Default Tech")
+    new_tech = _mock_tech("New Tech")
+
+    test_overrides = {
+        "shift1": ("id1", ["+New Tech"], "editor1"),
+    }
+    shift_people = [default_tech]
+
+    mocker.patch.object(
+        t.neon.cache,
+        "find_best_match",
+        side_effect=[
+            [new_tech],  # New Tech found
+        ],
+    )
+
+    got = t.resolve_overrides(test_overrides, "shift1", shift_people)
+    assert got[0] == "id1"
+    assert got[2] == "editor1"
+    # Should contain both the default tech and the added tech
+    assert len(got[1]) == 2
+    names = {p.name for p in got[1]}
+    assert names == {"Default Tech", "New Tech"}
+
+
+def test_resolve_overrides_delta_format_remove():
+    """Test delta format: removing a tech from a shift"""
+    default_tech = _mock_tech("Default Tech")
+    removed_tech = _mock_tech("Removed Tech")
+
+    test_overrides = {
+        "shift1": ("id1", ["-Removed Tech"], "editor1"),
+    }
+    shift_people = [default_tech, removed_tech]
+
+    # No neon lookup needed for removal (matched by name)
+    got = t.resolve_overrides(test_overrides, "shift1", shift_people)
+    assert got[0] == "id1"
+    assert got[2] == "editor1"
+    assert got[1] == [default_tech]
+
+
+def test_resolve_overrides_delta_format_add_and_remove(mocker):
+    """Test delta format: simultaneously adding and removing techs"""
+    default_tech = _mock_tech("Default Tech")
+    removed_tech = _mock_tech("Removed Tech")
+    new_tech = _mock_tech("New Tech")
+
+    test_overrides = {
+        "shift1": ("id1", ["+New Tech", "-Removed Tech"], "editor1"),
+    }
+    shift_people = [default_tech, removed_tech]
+
+    mocker.patch.object(
+        t.neon.cache,
+        "find_best_match",
+        side_effect=[
+            [new_tech],
+        ],
+    )
+
+    got = t.resolve_overrides(test_overrides, "shift1", shift_people)
+    assert got[0] == "id1"
+    assert got[2] == "editor1"
+    assert len(got[1]) == 2
+    names = {p.name for p in got[1]}
+    assert names == {"Default Tech", "New Tech"}
+
+
+def test_resolve_overrides_delta_format_guest_tech(mocker):
+    """Test delta format: adding a guest tech not found in Neon"""
+    default_tech = _mock_tech("Default Tech")
+
+    test_overrides = {
+        "shift1": ("id1", ["+Guest Tech"], "editor1"),
+    }
+    shift_people = [default_tech]
+
+    mocker.patch.object(
+        t.neon.cache,
+        "find_best_match",
+        side_effect=[
+            [],  # Guest Tech not found
+        ],
+    )
+
+    got = t.resolve_overrides(test_overrides, "shift1", shift_people)
+    assert got[0] == "id1"
+    assert got[2] == "editor1"
+    assert len(got[1]) == 2
+    names = {p.name for p in got[1]}
+    assert names == {"Default Tech", "Guest Tech"}
+
+
+def test_resolve_overrides_delta_format_new_tech_appears(mocker):
+    """Test that a newly enrolled tech with matching default shift appears
+    even when an override exists (the core bug fix)."""
+    # Scenario: override removes "Old Tech" and adds "Special Tech"
+    # A new tech "New Enrollee" has the same default shift
+    # They should appear in the final list because the override is a delta,
+    # not an absolute list
+
+    old_tech = _mock_tech("Old Tech")
+    new_enrollee = _mock_tech("New Enrollee")
+    special_tech = _mock_tech("Special Tech")
+
+    test_overrides = {
+        "shift1": ("id1", ["+Special Tech", "-Old Tech"], "editor1"),
+    }
+    shift_people = [old_tech, new_enrollee]
+
+    mocker.patch.object(
+        t.neon.cache,
+        "find_best_match",
+        side_effect=[
+            [special_tech],  # Special Tech found
+        ],
+    )
+
+    got = t.resolve_overrides(test_overrides, "shift1", shift_people)
+    assert got[0] == "id1"
+    # New Enrollee should be present (came from default shift)
+    # Special Tech should be present (added by override)
+    # Old Tech should be absent (removed by override)
+    names = {p.name for p in got[1]}
+    assert names == {"New Enrollee", "Special Tech"}
+
+
+def test_is_delta_format_detection(mocker):
+    """Test detection of delta vs legacy format via resolve_overrides.
+
+    Delta format entries (prefixed with +/-) apply on top of shift_people.
+    Legacy format entries (no prefix) replace shift_people entirely."""
+    default_tech = _mock_tech("Default Tech")
+
+    # Delta format: adds on top of shift_people
+    mocker.patch.object(
+        t.neon.cache, "find_best_match", side_effect=[[_mock_tech("New")]]
+    )
+    got = t.resolve_overrides({"s": ("id", ["+New"], "ed")}, "s", [default_tech])
+    assert len(got[1]) == 2  # Default Tech + New
+
+    # Legacy format: replaces shift_people entirely
+    mocker.patch.object(
+        t.neon.cache, "find_best_match", side_effect=[[_mock_tech("New")]]
+    )
+    got = t.resolve_overrides({"s": ("id", ["New"], "ed")}, "s", [default_tech])
+    assert len(got[1]) == 1  # Only New, Default Tech replaced
+    assert got[1][0].name == "New"
+
+    # Empty entries: no override
+    got = t.resolve_overrides({"s": ("id", [], "ed")}, "s", [default_tech])
     assert got == (None, [], None)

--- a/protohaven_api/handlers/techs.py
+++ b/protohaven_api/handlers/techs.py
@@ -270,6 +270,7 @@ def techs_forecast_override():
             date,
             ap,
             techs,
+            data.get("orig"),
             data.get("email"),
             fullname,
         )

--- a/protohaven_api/handlers/techs_test.py
+++ b/protohaven_api/handlers/techs_test.py
@@ -273,11 +273,21 @@ def test_techs_forecast_override_post(mocker, tech_client):
             "date": "2023-10-01",
             "ap": "AM",
             "techs": ["Tech1", "Tech2"],
+            "orig": ["Tech1"],
             "email": "john.doe@example.com",
         },
     )
     assert response.status_code == 200
     assert response.data.decode() == "Success"
+    tl.airtable.set_forecast_override.assert_called_once_with(
+        "123",
+        "2023-10-01",
+        "AM",
+        ["Tech1", "Tech2"],
+        ["Tech1"],
+        "john.doe@example.com",
+        "John Doe",
+    )
     tl.comms.send_discord_message.assert_called_once_with(
         MatchStr("Tech1, Tech2"), "#techs", blocking=False
     )

--- a/protohaven_api/integrations/airtable.py
+++ b/protohaven_api/integrations/airtable.py
@@ -906,16 +906,36 @@ def delete_forecast_override(rec):
 
 
 def set_forecast_override(  # pylint: disable=too-many-arguments
-    rec, date, ap, techs, editor_email, editor_name
+    rec, date, ap, techs, orig, editor_email, editor_name
 ):
-    """Upserts a shop tech shift override"""
+    """Upserts a shop tech shift override.
+
+    Stores a delta of the override relative to the default shift people (orig).
+    Lines starting with '+' indicate additions, '-' indicate removals.
+    This ensures newly enrolled techs with matching default shifts
+    automatically appear in previously-overridden shifts.
+    """
     ap = ap.lower()
     date = safe_parse_datetime(date).replace(
         hour=10 if ap.lower() == "am" else 16, minute=0, second=0, tzinfo=tz
     )
+    # Compute delta: +Name for additions, -Name for removals
+    orig_set = set(orig or [])
+    techs_set = set(techs or [])
+    additions = sorted(techs_set - orig_set)
+    removals = sorted(orig_set - techs_set)
+    delta_lines = [f"+{t}" for t in additions] + [f"-{t}" for t in removals]
+
+    # If delta is empty and an override record exists, delete it.
+    # If delta is empty and no record exists, no-op.
+    if not delta_lines:
+        if rec is not None:
+            return delete_record("people", "shop_tech_forecast_overrides", rec)
+        return 200, None
+
     data = {
         "Shift Start": date.isoformat(),
-        "Override": "\n".join(techs),
+        "Override": "\n".join(delta_lines),
         "Last Modified By": f"{editor_name} ({editor_email})",
     }
     if rec is not None:

--- a/svelte/src/lib/techs/shifts.svelte
+++ b/svelte/src/lib/techs/shifts.svelte
@@ -102,6 +102,8 @@ function start_edit(s, ap) {
  let e = {ap: ap, date: s.date, techs: s[ap].people, ...user};
  if (s[ap].ovr) {
    e = {...e, id: s[ap].ovr.id, orig: s[ap].ovr.orig, editor: s[ap].ovr.editor};
+ } else {
+   e = {...e, orig: [...s[ap].people]};
  }
  edit = e;
 }


### PR DESCRIPTION
#267

Store shift overrides as delta entries (+Name for additions, -Name for removals) rather than absolute lists of tech names. This fixes a bug where newly enrolled techs with matching default shifts would be excluded from previously-overridden shifts.

Changes:
- airtable.py: set_forecast_override computes delta from orig vs techs, stores +/- prefixed lines; empty delta deletes the override record
- techs.py: resolve_overrides accepts shift_people, applies delta on top of defaults; legacy absolute-format overrides still supported
- handlers/techs.py: passes orig to set_forecast_override
- shifts.svelte: always sends orig (default shift people) when editing
- Comprehensive tests for delta format, legacy compat, and the core bug fix