### PR TITLE
fix: defer Asana task completion until after Discord message send

### DIFF
--- a/protohaven_api/commands/comms.py
+++ b/protohaven_api/commands/comms.py
@@ -15,6 +15,7 @@ from protohaven_api.commands.decorator import arg, command
 from protohaven_api.integrations import (  # pylint: disable=import-error
     airtable,
     comms,
+    tasks,
 )
 
 log = logging.getLogger("cli.comms")
@@ -75,14 +76,6 @@ class Commands:  # pylint: disable=too-few-public-methods
 
     def _handle_comms_event(self, e, apply):
         """Handle a single entry in a comms YAML file"""
-        for k, v in e.get("side_effect", {}).items():
-            if k.lower().strip() == "cancel":
-                log.info(f"Cancelling #{v}")
-                if apply:
-                    log.info(
-                        str(eauto.set_event_scheduled_state(str(v), scheduled=False))
-                    )
-
         if e["target"][0] in ("#", "@"):  # channels or users
             target = self._handle_discord(
                 e, apply, getenv("CHAN_OVERRIDE"), getenv("DM_OVERRIDE")
@@ -94,6 +87,22 @@ class Commands:  # pylint: disable=too-few-public-methods
             not target
         ):  # Only set when the action made a change; ignore apply=False and failure
             return
+
+        # Side effects happen AFTER successful message delivery.
+        # This ensures tasks aren't marked complete if the message fails to send.
+        for k, v in e.get("side_effect", {}).items():
+            k = k.lower().strip()
+            if k == "cancel":
+                log.info(f"Cancelling #{v}")
+                if apply:
+                    log.info(
+                        str(eauto.set_event_scheduled_state(str(v), scheduled=False))
+                    )
+            elif k == "complete_asana_task":
+                log.info(f"Completing Asana task #{v}")
+                if apply:
+                    tasks.complete(str(v))
+                    log.info(f"marked complete: {v}")
 
         airtable.log_comms(e.get("id", ""), ", ".join(target), e["subject"], "Sent")
         log.info("Logged to airtable")

--- a/protohaven_api/commands/comms_test.py
+++ b/protohaven_api/commands/comms_test.py
@@ -11,8 +11,8 @@ from protohaven_api.testing import idfn, mkcli
 
 Tc = namedtuple(
     "Tc",
-    "desc,data,args,email,log,discord,intents_notified,scheduled_state",
-    defaults=[None for _ in range(7)],
+    "desc,data,args,email,log,discord,intents_notified,scheduled_state,asana_complete",
+    defaults=[None for _ in range(8)],
 )
 
 
@@ -121,6 +121,19 @@ def fixture_cli(capsys):
             ],
             ["--no-apply"],
         ),
+        Tc(
+            "Side effect complete_asana_task",
+            {
+                "target": "@testuser",
+                "subject": "Test Subject",
+                "body": "Test Body",
+                "side_effect": {"complete_asana_task": "999"},
+            },
+            [],
+            log=call("", "@testuser", "Test Subject", "Sent"),
+            discord=call("Test Subject\n\nTest Body", "@testuser"),
+            asana_complete=call("999"),
+        ),
     ],
     ids=idfn,
 )
@@ -131,6 +144,7 @@ def test_send_comms(mocker, tc, cli):
     mocker.patch.object(c.airtable, "log_intents_notified")
     mocker.patch.object(c.airtable, "log_comms")
     mocker.patch.object(c.eauto, "set_event_scheduled_state")
+    mocker.patch.object(c.tasks, "complete")
     mocker.patch.object(
         c.Commands,
         "_load_comms_data",
@@ -145,6 +159,7 @@ def test_send_comms(mocker, tc, cli):
         (c.comms.send_discord_message, tc.discord),
         (c.airtable.log_intents_notified, tc.intents_notified),
         (c.eauto.set_event_scheduled_state, tc.scheduled_state),
+        (c.tasks.complete, tc.asana_complete),
     ]:
         if tcall:
             fn.assert_has_calls([tcall])

--- a/protohaven_api/commands/forwarding.py
+++ b/protohaven_api/commands/forwarding.py
@@ -24,7 +24,8 @@ class Commands:
     @command(
         arg(
             "--apply",
-            help="when true, Asana tasks are completed when comms are generated",
+            help="when true, side effects (e.g. completing Asana tasks) "
+            "are included in the generated comms YAML",
             action=argparse.BooleanOptionalAction,
             default=False,
         ),
@@ -54,14 +55,15 @@ class Commands:
                 )
                 continue
 
+            side_effect = {"complete_asana_task": req["gid"]} if args.apply else {}
             results.append(
                 Msg.tmpl(
-                    "new_project_request", notes=req["notes"], target="#help-wanted"
+                    "new_project_request",
+                    notes=req["notes"],
+                    target="#help-wanted",
+                    side_effect=side_effect,
                 )
             )
-            if args.apply:
-                tasks.complete(req["gid"])
-                log.info(f"marked complete: {req['gid']}")
             num += 1
         log.info(f"Done - {num} project request(s) generated")
 
@@ -284,7 +286,8 @@ class Commands:
     @command(
         arg(
             "--apply",
-            help="when true, Asana tasks are completed when comms are generated",
+            help="when true, side effects (e.g. completing Asana tasks) "
+            "are included in the generated comms YAML",
             action=argparse.BooleanOptionalAction,
             default=False,
         ),
@@ -301,6 +304,7 @@ class Commands:
         for req in tasks.get_phone_messages():
             if req.get("completed"):
                 continue
+            side_effect = {"complete_asana_task": req["gid"]} if args.apply else {}
             results.append(
                 Msg.tmpl(
                     "phone_message",
@@ -308,11 +312,9 @@ class Commands:
                     msg_header=req["name"].split(",")[0],
                     date=safe_parse_datetime(req["created_at"]),
                     notes=req["notes"],
+                    side_effect=side_effect,
                 )
             )
-            if args.apply:
-                tasks.complete(req["gid"])
-                log.info(f"marked complete: {req['gid']}")
             num += 1
         log.info(f"Found {num} open phone messages")
 

--- a/protohaven_api/commands/forwarding_test.py
+++ b/protohaven_api/commands/forwarding_test.py
@@ -185,15 +185,42 @@ def test_project_requests(mocker, cli):
         ],
     )
     mocker.patch.object(F, "tznow", return_value=d(0))
-    mocker.patch.object(F.tasks, "complete")
-    assert cli("project_requests", ["--apply"]) == [
+    got = cli("project_requests", ["--apply"])
+    assert got == [
+        {
+            "body": MatchStr("Test Desc"),
+            "subject": MatchStr("Project Request"),
+            "target": "#help-wanted",
+            "side_effect": {"complete_asana_task": "123"},
+        }
+    ]
+
+
+def test_project_requests_no_apply(mocker, cli):
+    """Test that --no-apply omits side_effect"""
+    mocker.patch.object(
+        F.tasks,
+        "get_project_requests",
+        return_value=[
+            {
+                "gid": "123",
+                "name": "Foo",
+                "notes": (
+                    f"Project Description:\\nTest Desc\\nMaterials Budget: $5\\n"
+                    f"Deadline for Project Completion:\\n{d(1).isoformat()}\\n"
+                ),
+            }
+        ],
+    )
+    mocker.patch.object(F, "tznow", return_value=d(0))
+    got = cli("project_requests", ["--no-apply"])
+    assert got == [
         {
             "body": MatchStr("Test Desc"),
             "subject": MatchStr("Project Request"),
             "target": "#help-wanted",
         }
     ]
-    F.tasks.complete.assert_called_with("123")  # pylint: disable=no-member
 
 
 def test_shop_tech_applications(mocker, cli):
@@ -300,15 +327,39 @@ def test_phone_messages(mocker, cli):
             }
         ],
     )
-    mocker.patch.object(F.tasks, "complete", return_value=None)
-    assert cli("phone_messages", ["--apply"]) == [
+    got = cli("phone_messages", ["--apply"])
+    assert got == [
+        {
+            "body": MatchStr("test notes"),
+            "subject": MatchStr("phone message"),
+            "target": "hello@protohaven.org",
+            "side_effect": {"complete_asana_task": "123"},
+        }
+    ]
+
+
+def test_phone_messages_no_apply(mocker, cli):
+    """Test `phone_messages` cli command without apply"""
+    mocker.patch.object(
+        F.tasks,
+        "get_phone_messages",
+        return_value=[
+            {
+                "gid": "123",
+                "name": "Foo",
+                "created_at": d(0).isoformat(),
+                "notes": "test notes",
+            }
+        ],
+    )
+    got = cli("phone_messages", ["--no-apply"])
+    assert got == [
         {
             "body": MatchStr("test notes"),
             "subject": MatchStr("phone message"),
             "target": "hello@protohaven.org",
         }
     ]
-    F.tasks.complete.assert_called_with("123")  # pylint: disable=no-member
 
 
 def test_donation_requests(mocker, cli):


### PR DESCRIPTION
#562

Move task completion from project_requests and phone_messages commands into send_comms side_effect handlers. Previously, tasks were marked complete in the generator commands before send_comms actually sent the Discord message - if the send failed, the task was already completed and wouldn't be retried on the next cron run.

Changes:
- forwarding.py: Replace tasks.complete() calls with side_effect dict on Msg objects ('complete_asana_task')
- comms.py: Move side_effect processing to AFTER successful message delivery; add 'complete_asana_task' handler
- Also fixes the same bug in phone_messages command