### PR TITLE
fix: handle empty shop events calendar gracefully

### DIFF
--- a/protohaven_api/integrations/schedule.py
+++ b/protohaven_api/integrations/schedule.py
@@ -21,8 +21,6 @@ def fetch_calendar(calendar_id, time_min=None, time_max=None):
         time_max = datetime.utcnow() + timedelta(days=30)
     events_result = get_connector().gcal_request(calendar_id, time_min, time_max)
     events = events_result.get("items", [])
-    if not events:
-        raise RuntimeError("No upcoming events found.")
     # Bin by event (aka instructor) name
     output = defaultdict(list)
     for event in events:

--- a/svelte/src/lib/events/gcal.svelte
+++ b/svelte/src/lib/events/gcal.svelte
@@ -18,11 +18,15 @@ import FetchError from '../fetch_error.svelte';
   {#await promise}
       <Spinner/>
   {:then p}
-    <ListGroup>
-    {#each p as evt }
-    <ListGroupItem>{new Date(evt.start).toLocaleString('en-US', { timeZone: 'America/New_York' })}: {evt.name}</ListGroupItem>
-    {/each}
-    </ListGroup>
+    {#if p.length === 0}
+      <p>No upcoming events in the schedule!</p>
+    {:else}
+      <ListGroup>
+      {#each p as evt }
+      <ListGroupItem>{new Date(evt.start).toLocaleString('en-US', { timeZone: 'America/New_York' })}: {evt.name}</ListGroupItem>
+      {/each}
+      </ListGroup>
+    {/if}
   {:catch error}
     <FetchError {error}/>
   {/await}


### PR DESCRIPTION
- schedule.py: return empty dict instead of raising RuntimeError when no calendar events found, so the /events/shop endpoint returns an empty list rather than a 500 error
- gcal.svelte: display 'No upcoming events in the schedule!' message when the shop events list is empty, instead of showing an error alert

Fixes #113