### PR TITLE
fix: add gevent>=24.10.1 to requirements.txt for gunicorn 26.0.0 geve…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ squareup-legacy==41.0.0.20250319
 wyze_sdk @ git+https://github.com/smartin015/wyze-sdk@2ff7f51bdd1b078630c29f778d0598fd1d777078
 paho-mqtt==2.1.0
 certifi==2026.7.22
+gevent>=24.10.1


### PR DESCRIPTION
…nt worker support

Gunicorn 26.0.0's gevent worker requires gevent >= 24.10.1 but gevent was missing entirely from requirements.txt, causing a RuntimeError in production when using gevent worker processes.

#596